### PR TITLE
Add a named export for SpheronClient

### DIFF
--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -32,7 +32,7 @@
 In the example below you can see how to create an instance of `SpheronClient` and how to upload a file/directory to the specified protocol.
 
 ```js
-import SpheronClient, { ProtocolEnum } from "@spheron/storage";
+import { SpheronClient, ProtocolEnum } from "@spheron/storage";
 
 const client = new SpheronClient({ token });
 let currentlyUploaded = 0;
@@ -68,7 +68,7 @@ const { uploadId, bucketId, protocolLink, dynamicLinks } = await client.upload(
 
 ## Access Token
 
-To create the `token` that is used with the `SpheronClient`, follow the instructions in the [DOCS](https://docs.spheron.network/api/rest-api-references#creating-an-access-token).
+To create the `token` that is used with the `SpheronClient`, follow the instructions in the [DOCS](https://docs.spheron.network/api/rest-api-references#creating-an-access-token). Only tokens for web app organizations will work.
 
 ## Learn More
 

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">  
   <a href="https://www.npmjs.com/package/@spheron/storage" target="_blank" rel="noreferrer">
-    <img src="https://img.shields.io/static/v1?label=npm&message=v1.0.6&color=green" />
+    <img src="https://img.shields.io/static/v1?label=npm&message=v1.0.7&color=green" />
   </a>
   <a href="https://github.com/spheronFdn/sdk/blob/main/LICENSE" target="_blank" rel="noreferrer">
     <img src="https://img.shields.io/static/v1?label=license&message=Apache%202.0&color=red" />

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/storage",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Typescript library for uploading files or directory to  IPFS, Filecoin or Arweave via Spheron",
   "keywords": [
     "Storage",

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -7,7 +7,7 @@ export interface SpheronClientConfiguration {
   token: string;
 }
 
-export default class SpheronClient {
+export class SpheronClient {
   private readonly configuration: SpheronClientConfiguration;
 
   constructor(configuration: SpheronClientConfiguration) {
@@ -35,3 +35,5 @@ export default class SpheronClient {
     });
   }
 }
+
+export default SpheronClient;

--- a/packages/storage/src/upload-manager/index.ts
+++ b/packages/storage/src/upload-manager/index.ts
@@ -39,7 +39,11 @@ class UploadManager {
     this.validateUploadConfiguration(configuration);
 
     const { deploymentId, payloadSize, parallelUploadCount } =
-      await this.startDeployment(configuration.protocol, configuration.name, configuration.organizationId);
+      await this.startDeployment(
+        configuration.protocol,
+        configuration.name,
+        configuration.organizationId
+      );
 
     configuration.onUploadInitiated &&
       configuration.onUploadInitiated(deploymentId);
@@ -83,18 +87,14 @@ class UploadManager {
   }> {
     try {
       let url = `${this.uploadApiUrl}/v1/upload-deployment?protocol=${protocol}&project=${projectName}`;
-      if(organizationId){
+      if (organizationId) {
         url += `&organization=${organizationId}`;
       }
       const response = await axios.post<{
         deploymentId: string;
         parallelUploadCount: number;
         payloadSize: number;
-      }>(
-        url,
-        {},
-        this.getAxiosRequestConfig()
-      );
+      }>(url, {}, this.getAxiosRequestConfig());
       return response.data;
     } catch (error) {
       const errorMessage = error?.response?.data?.message || error?.message;


### PR DESCRIPTION
PR Includes:
- Formmating in /upload-manager/index.ts
- Updated the README.md
- Changed the `SpheronClient` to be both the named export and default one.


Completes SPH-1544
Linear: https://linear.app/spheron/issue/SPH-1544/update-the-storage-sdk-to-have-a-named-export-for-spheronclient-class