### PR TITLE
refactor: use fetch instead of axios

### DIFF
--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -35,7 +35,6 @@
     "dist/"
   ],
   "dependencies": {
-    "axios": "^1.3.2",
     "form-data": "^4.0.0",
     "p-limit": "^3.0.0"
   },

--- a/packages/storage/src/spheron-api/index.ts
+++ b/packages/storage/src/spheron-api/index.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import { deleteData, getData, patchData, postData, putData } from "../utils";
 import {
   DeploymentStatusEnum,
   DomainTypeEnum,
@@ -183,15 +183,27 @@ class SpheronApi {
     payload?: any
   ): Promise<T> {
     try {
-      const response = await axios<T>({
-        method,
-        url: `${this.spheronApiUrl}${path}`,
-        data: payload,
-        headers: {
-          Authorization: `Bearer ${this.token}`,
-        },
-      });
-      return response.data;
+      const url = `${this.spheronApiUrl}${path}`;
+      const token = this.token;
+      let response;
+
+      switch(method){
+        case HttpMethods.GET: 
+          response  = await getData(url, token);
+          break;
+        case HttpMethods.POST: 
+          response  = await postData(url, payload, token);
+          break;
+        case HttpMethods.PUT: 
+          response  = await putData(url, payload, token);
+          break;
+        case HttpMethods.PATCH: 
+          response  = await patchData(url, payload, token);
+          break;          
+        case HttpMethods.DELETE: 
+          response  = await deleteData(url, token);
+      }
+     return response
     } catch (error) {
       throw new Error(error.response?.data?.message || error?.message);
     }

--- a/packages/storage/src/utils.ts
+++ b/packages/storage/src/utils.ts
@@ -1,0 +1,78 @@
+export async function postData(url = "", data = {}, token="") {
+  // Default options are marked with *
+  const response = await fetch(url, {
+    method: "POST", // *GET, POST, PUT, DELETE, etc.
+    cache: "no-cache", // *default, no-cache, reload, force-cache, only-if-cached
+    mode: 'no-cors', // no-cors, *cors, same-origin
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    redirect: "follow", // manual, *follow, error
+    referrerPolicy: "no-referrer", // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url
+    body: JSON.stringify(data), // body data type must match "Content-Type" header
+  });
+  return response.json(); // parses JSON response into native JavaScript objects
+}
+
+export async function putData(url = "", data = {}, token="") {
+  // Default options are marked with *
+  const response = await fetch(url, {
+    method: "PUT", // *GET, POST, PUT, DELETE, etc.
+    cache: "no-cache", // *default, no-cache, reload, force-cache, only-if-cached
+    mode: 'no-cors', // no-cors, *cors, same-origin
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    redirect: "follow", // manual, *follow, error
+    referrerPolicy: "no-referrer", // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url
+    body: JSON.stringify(data), // body data type must match "Content-Type" header
+  });
+  return response.json(); // parses JSON response into native JavaScript objects
+}
+
+export async function patchData(url = "", data = {}, token="") {
+  // Default options are marked with *
+  const response = await fetch(url, {
+    method: "PATCH", // *GET, POST, PUT, DELETE, etc.
+    cache: "no-cache", // *default, no-cache, reload, force-cache, only-if-cached
+    mode: 'no-cors', // no-cors, *cors, same-origin
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    redirect: "follow", // manual, *follow, error
+    referrerPolicy: "no-referrer", // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url
+    body: JSON.stringify(data), // body data type must match "Content-Type" header
+  });
+  return response.json(); // parses JSON response into native JavaScript objects
+}
+
+
+export async function getData(url: string, token="") {
+  const response = await fetch(url, {
+    method: 'GET', // *GET, POST, PUT, DELETE, etc.
+    mode: 'no-cors', // no-cors, *cors, same-origin
+    headers: {
+      'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+    },
+  });
+
+  return response.json();
+}
+
+export async function deleteData(url: string, token="") {
+  const response = await fetch(url, {
+    method: 'DELETE', // *GET, POST, PUT, DELETE, etc.
+    mode: 'no-cors', // no-cors, *cors, same-origin
+    headers: {
+      'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+
+    },
+  });
+
+  return response.json();
+}


### PR DESCRIPTION
Replaced axios with fetch. For some strange reason there are errors about axios like the one below

```
index.js:227 Uncaught (in promise) Error: import_axios.default.post is not a function
    at UploadManager.<anonymous> (index.js:227:1)
    at Generator.next (<anonymous>)
    at index.js:63:1
    at new Promise (<anonymous>)
    at __async (index.js:47:1)
    at UploadManager.startDeployment (index.js:216:1)
    at UploadManager.<anonymous> (index.js:185:1)
    at Generator.next (<anonymous>)
    at index.js:63:1
    at new Promise (<anonymous>)
```