### PR TITLE
Improve error handling

### DIFF
--- a/examples/browser-upload/client/package.json
+++ b/examples/browser-upload/client/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "homepage": "./",
   "dependencies": {
-    "@spheron/browser-upload": "^1.0.0",
+    "@spheron/browser-upload": "^1.0.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5961,7 +5961,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spheron/core": "1.0.1",
+        "@spheron/core": "1.0.2",
         "form-data": "^4.0.0",
         "jwt-decode": "^3.1.2"
       },
@@ -6019,7 +6019,7 @@
     },
     "packages/core": {
       "name": "@spheron/core",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "1.1.2",
@@ -6046,10 +6046,10 @@
     },
     "packages/storage": {
       "name": "@spheron/storage",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spheron/core": "1.0.1",
+        "@spheron/core": "1.0.2",
         "form-data": "^4.0.0",
         "multiformats": "^9.9.0"
       },
@@ -7596,7 +7596,7 @@
     "@spheron/browser-upload": {
       "version": "file:packages/browser-upload",
       "requires": {
-        "@spheron/core": "1.0.1",
+        "@spheron/core": "1.0.2",
         "@types/node": "^18.13.0",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
@@ -7670,7 +7670,7 @@
     "@spheron/storage": {
       "version": "file:packages/storage",
       "requires": {
-        "@spheron/core": "1.0.1",
+        "@spheron/core": "1.0.2",
         "@types/node": "^18.13.0",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5958,7 +5958,7 @@
     },
     "packages/browser-upload": {
       "name": "@spheron/browser-upload",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@spheron/core": "1.0.2",

--- a/packages/browser-upload/package.json
+++ b/packages/browser-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/browser-upload",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Typescript library for uploading files or directory from the Browser to  IPFS, Filecoin or Arweave via Spheron",
   "keywords": [
     "Storage",

--- a/packages/browser-upload/package.json
+++ b/packages/browser-upload/package.json
@@ -35,7 +35,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@spheron/core": "1.0.1",
+    "@spheron/core": "1.0.2",
     "form-data": "^4.0.0",
     "jwt-decode": "^3.1.2"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Shared core package for all sdk packages",
   "keywords": [
     "Storage",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/storage",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Typescript library for uploading files or directory to  IPFS, Filecoin or Arweave via Spheron",
   "keywords": [
     "Storage",
@@ -35,7 +35,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@spheron/core": "1.0.1",
+    "@spheron/core": "1.0.2",
     "form-data": "^4.0.0",
     "multiformats": "^9.9.0"
   },


### PR DESCRIPTION
- [x] Test out storage
- [x] Test out browser

PR Will:
- Improve the error handling when uploading files
  - If an error occurred on `onUploadInitiated` or while creating payloads, we wouldn't close the upload, which would mean the user would need to wait for 10 minutes for it to expire.
  - If an error occurred in `uploadPayloads`, we would catch it but we would throw a generic one `Upload Failed...`
- Increase the version of @spheron/core
- Increase the version of @spheron/storage
- Increase the version of @spheron/browser-upload
- Increase the version of @spheron/browser-upload in the example