### PR TITLE
Add deploymentId as response createSingleUploadToken

### DIFF
--- a/examples/browser-upload/server/index.js
+++ b/examples/browser-upload/server/index.js
@@ -20,13 +20,14 @@ app.get("/initiate-upload", async (req, res, next) => {
       token: SPHERON_TOKEN,
     });
 
-    const { uploadToken } = await client.createSingleUploadToken({
+    const { uploadToken, deploymentId } = await client.createSingleUploadToken({
       name: bucketName,
       protocol,
     });
 
     res.status(200).json({
       uploadToken,
+      deploymentId
     });
   } catch (error) {
     console.error(error);

--- a/packages/browser-upload/README.md
+++ b/packages/browser-upload/README.md
@@ -41,7 +41,6 @@ const response = await fetch(`<BACKEND_URL>/initiate-upload`);
 import { SpheronClient, ProtocolEnum } from "@spheron/storage";
 
 ...
-git config user.name "Suraj Singla"
 app.get("/initiate-upload", async (req, res, next) => {
   try {
     const bucketName = "example-browser-upload"; // use which ever name you prefer

--- a/packages/browser-upload/README.md
+++ b/packages/browser-upload/README.md
@@ -35,13 +35,13 @@ The general usage flow would be as:
 const response = await fetch(`<BACKEND_URL>/initiate-upload`);
 ```
 
-2. On your BE service, use the method `createSingleUploadToken` from [@spheron/storage](https://www.npmjs.com/package/@spheron/storage) package. This method will provide you with a unique token that can only be used for a single upload with the `upload` function from [@spheron/browser-upload](https://www.npmjs.com/package/@spheron/browser-upload), and this token has a expiration of 10 minutes.
+2. On your BE service, use the method `createSingleUploadToken` from [@spheron/storage](https://www.npmjs.com/package/@spheron/storage) package. This method will provide you with a unique token and the deploymentId. The token can only be used for a single upload with the `upload` function from [@spheron/browser-upload](https://www.npmjs.com/package/@spheron/browser-upload), and this token has a expiration of 10 minutes.
 
 ```js
 import { SpheronClient, ProtocolEnum } from "@spheron/storage";
 
 ...
-
+git config user.name "Suraj Singla"
 app.get("/initiate-upload", async (req, res, next) => {
   try {
     const bucketName = "example-browser-upload"; // use which ever name you prefer
@@ -51,13 +51,14 @@ app.get("/initiate-upload", async (req, res, next) => {
       token: <SPHERON_TOKEN>,
     });
 
-    const { uploadToken } = await client.createSingleUploadToken({
+    const { uploadToken, deploymentId } = await client.createSingleUploadToken({
       name: bucketName,
       protocol,
     });
 
     res.status(200).json({
       uploadToken,
+      deploymentId
     });
   } catch (error) {
     console.error(error);
@@ -117,7 +118,7 @@ const uploadResult = await upload(files, {
 
 ## Access Token
 
-To create a token you should use the method `createSingleUploadToken` from [@spheron/storage](https://www.npmjs.com/package/@spheron/storage) package on you Backend service. This method will generate a unique token that can be used only for a single upload.
+To create a token you should use the method `createSingleUploadToken` from [@spheron/storage](https://www.npmjs.com/package/@spheron/storage) package on you Backend service. This method will generate a unique token that can be used only for a single upload and the deploymentId for the upload.
 
 ## Notes
 

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -163,7 +163,7 @@ The `SpheronClient` instance provides several methods for working with buckets. 
   - get all IPNS names for an upload id
 - `async getIPNSNamesForOrganization(organizationId: string): Promise<IPNSName[]>`
   - get all IPNS names for an organization
-- `async createSingleUploadToken(configuration: { name: string; protocol: ProtocolEnum; }): Promise<{ uploadToken: string }>`
+- `async createSingleUploadToken(configuration: { name: string; protocol: ProtocolEnum; }): Promise<{ uploadToken: string, deploymentId: string }>`
   - used to create a token for the **@spheron/browser-upload** package. The token can be used by your web app to enable users to directly upload their data from their browser to the specified protocol. Checkout the [@spheron/browser-upload](https://www.npmjs.com/package/@spheron/browser-upload) package for more information.
 
 Interfaces:

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -105,8 +105,8 @@ export class SpheronClient {
   async createSingleUploadToken(configuration: {
     name: string;
     protocol: ProtocolEnum;
-  }): Promise<{ uploadToken: string }> {
-    const { singleDeploymentToken } =
+  }): Promise<{ uploadToken: string, deploymentId: string }> {
+    const { singleDeploymentToken, deploymentId } =
       await this.uploadManager.initiateDeployment({
         protocol: configuration.protocol,
         name: configuration.name,
@@ -115,7 +115,7 @@ export class SpheronClient {
       });
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return { uploadToken: singleDeploymentToken! };
+    return { uploadToken: singleDeploymentToken!, deploymentId:deploymentId };
   }
 
   async getBucket(bucketId: string): Promise<Bucket> {


### PR DESCRIPTION
While generating a `uploadToken`, the user might want to have the `deploymentId` since that is used to cancel the upload and thus added the same in response of `createSingleUploadToken()`.