### PR TITLE
Add support for FileList object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5958,7 +5958,7 @@
     },
     "packages/browser-upload": {
       "name": "@spheron/browser-upload",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@spheron/core": "1.0.2",
@@ -6019,7 +6019,7 @@
     },
     "packages/core": {
       "name": "@spheron/core",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "1.1.2",
@@ -6046,10 +6046,10 @@
     },
     "packages/storage": {
       "name": "@spheron/storage",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spheron/core": "1.0.2",
+        "@spheron/core": "1.0.3",
         "form-data": "^4.0.0",
         "multiformats": "^9.9.0"
       },
@@ -7670,7 +7670,7 @@
     "@spheron/storage": {
       "version": "file:packages/storage",
       "requires": {
-        "@spheron/core": "1.0.2",
+        "@spheron/core": "1.0.3",
         "@types/node": "^18.13.0",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",

--- a/packages/browser-upload/package.json
+++ b/packages/browser-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/browser-upload",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Typescript library for uploading files or directory from the Browser to  IPFS, Filecoin or Arweave via Spheron",
   "keywords": [
     "Storage",

--- a/packages/browser-upload/src/index.ts
+++ b/packages/browser-upload/src/index.ts
@@ -5,13 +5,21 @@ import jwt_decode from "jwt-decode";
 export { ProtocolEnum, UploadResult };
 
 async function upload(
-  files: File[],
+  files: File[] | FileList,
   configuration: {
     token: string;
     onChunkUploaded?: (uploadedSize: number, totalSize: number) => void;
   }
 ): Promise<UploadResult> {
-  if (!files || files.length === 0) {
+  let fileList: File[] = [];
+
+  if (files instanceof FileList) {
+    fileList = Array.from(files);
+  } else if (Array.isArray(files)) {
+    fileList = files;
+  }
+
+  if (!fileList || fileList.length === 0) {
     throw new Error("No files to upload.");
   }
 
@@ -32,7 +40,7 @@ async function upload(
   const payloadSize = jwtPayload?.payloadSize ?? 5 * 5 * 1024;
   const parallelUploadCount = jwtPayload?.parallelUploadCount ?? 3;
 
-  const { payloads, totalSize } = await createPayloads(files, payloadSize);
+  const { payloads, totalSize } = await createPayloads(fileList, payloadSize);
 
   let success = true;
   let caughtError: Error | undefined = undefined;


### PR DESCRIPTION
This PR will:
- Add support for the `FileList` object for uploading files on `browser-upload` package.
- Increase the version of the `browser-upload` package to `1.0.2`