### PR TITLE
Add cid to the output of upload functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5994,7 +5994,7 @@
       "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spheron/core": "1.0.2",
+        "@spheron/core": "1.0.6",
         "form-data": "^4.0.0",
         "jwt-decode": "^3.1.2"
       },
@@ -6008,28 +6008,9 @@
         "typescript": "^4.9.5"
       }
     },
-    "packages/browser-upload/node_modules/@spheron/core": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.2.tgz",
-      "integrity": "sha512-Zcel3lEQkJpfXw+mFbMZhufoH9uwm9i9pBg+4wjvqR4/8Fh5lmSbXYK0iKltjCb97q520iQbJb8rcP9TKtksNQ==",
-      "dependencies": {
-        "axios": "1.1.2",
-        "p-limit": "^3.0.0"
-      }
-    },
-    "packages/browser-upload/node_modules/axios": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
-      "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "packages/cli": {
       "name": "@spheron/cli",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6088,7 +6069,7 @@
     },
     "packages/core": {
       "name": "@spheron/core",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "1.1.2",
@@ -6134,12 +6115,32 @@
         "typescript": "^4.9.5"
       }
     },
+    "packages/site/node_modules/@spheron/core": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.5.tgz",
+      "integrity": "sha512-frXn0mQBRqvO5LBk54Jc23ZdyCZxr8lpcwhRS8xI/WwK7LyX8/n/NK4Yrg4sTDKVzVl8ooBjyOho40c8nHrsNQ==",
+      "dependencies": {
+        "axios": "1.1.2",
+        "eventsource": "^2.0.2",
+        "p-limit": "^3.0.0"
+      }
+    },
+    "packages/site/node_modules/axios": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
+      "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "packages/storage": {
       "name": "@spheron/storage",
       "version": "1.0.15",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spheron/core": "1.0.3",
+        "@spheron/core": "1.0.6",
         "form-data": "^4.0.0",
         "multiformats": "^9.9.0"
       },
@@ -6151,25 +6152,6 @@
         "prettier": "^2.8.3",
         "tsup": "^6.5.0",
         "typescript": "^4.9.5"
-      }
-    },
-    "packages/storage/node_modules/@spheron/core": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.3.tgz",
-      "integrity": "sha512-5TulB3IqhMDI3tANepsW6LZLeBgHYVCNPjha9DiLYIPhTI2cpJG1zVWN9E7/xwK9/YdxBqbNuMF8/u/fCd5/Qw==",
-      "dependencies": {
-        "axios": "1.1.2",
-        "p-limit": "^3.0.0"
-      }
-    },
-    "packages/storage/node_modules/axios": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
-      "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "packages/web-app": {
@@ -7723,7 +7705,7 @@
     "@spheron/browser-upload": {
       "version": "file:packages/browser-upload",
       "requires": {
-        "@spheron/core": "1.0.2",
+        "@spheron/core": "1.0.6",
         "@types/node": "^18.13.0",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
@@ -7733,27 +7715,6 @@
         "prettier": "^2.8.3",
         "tsup": "^6.5.0",
         "typescript": "^4.9.5"
-      },
-      "dependencies": {
-        "@spheron/core": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.2.tgz",
-          "integrity": "sha512-Zcel3lEQkJpfXw+mFbMZhufoH9uwm9i9pBg+4wjvqR4/8Fh5lmSbXYK0iKltjCb97q520iQbJb8rcP9TKtksNQ==",
-          "requires": {
-            "axios": "1.1.2",
-            "p-limit": "^3.0.0"
-          }
-        },
-        "axios": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
-          "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
-          "requires": {
-            "follow-redirects": "^1.15.0",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        }
       }
     },
     "@spheron/cli": {
@@ -7843,29 +7804,15 @@
         "prettier": "^2.8.3",
         "tsup": "^6.5.0",
         "typescript": "^4.9.5"
-      }
-    },
-    "@spheron/storage": {
-      "version": "file:packages/storage",
-      "requires": {
-        "@spheron/core": "1.0.3",
-        "@types/node": "^18.13.0",
-        "@typescript-eslint/eslint-plugin": "^5.51.0",
-        "@typescript-eslint/parser": "^5.51.0",
-        "eslint": "^8.33.0",
-        "form-data": "^4.0.0",
-        "multiformats": "^9.9.0",
-        "prettier": "^2.8.3",
-        "tsup": "^6.5.0",
-        "typescript": "^4.9.5"
       },
       "dependencies": {
         "@spheron/core": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.3.tgz",
-          "integrity": "sha512-5TulB3IqhMDI3tANepsW6LZLeBgHYVCNPjha9DiLYIPhTI2cpJG1zVWN9E7/xwK9/YdxBqbNuMF8/u/fCd5/Qw==",
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.5.tgz",
+          "integrity": "sha512-frXn0mQBRqvO5LBk54Jc23ZdyCZxr8lpcwhRS8xI/WwK7LyX8/n/NK4Yrg4sTDKVzVl8ooBjyOho40c8nHrsNQ==",
           "requires": {
             "axios": "1.1.2",
+            "eventsource": "^2.0.2",
             "p-limit": "^3.0.0"
           }
         },
@@ -7879,6 +7826,21 @@
             "proxy-from-env": "^1.1.0"
           }
         }
+      }
+    },
+    "@spheron/storage": {
+      "version": "file:packages/storage",
+      "requires": {
+        "@spheron/core": "1.0.6",
+        "@types/node": "^18.13.0",
+        "@typescript-eslint/eslint-plugin": "^5.51.0",
+        "@typescript-eslint/parser": "^5.51.0",
+        "eslint": "^8.33.0",
+        "form-data": "^4.0.0",
+        "multiformats": "^9.9.0",
+        "prettier": "^2.8.3",
+        "tsup": "^6.5.0",
+        "typescript": "^4.9.5"
       }
     },
     "@types/async-lock": {

--- a/packages/browser-upload/package.json
+++ b/packages/browser-upload/package.json
@@ -35,7 +35,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@spheron/core": "1.0.2",
+    "@spheron/core": "1.0.6",
     "form-data": "^4.0.0",
     "jwt-decode": "^3.1.2"
   },

--- a/packages/browser-upload/src/index.ts
+++ b/packages/browser-upload/src/index.ts
@@ -81,6 +81,7 @@ async function upload(
     bucketId: result.projectId,
     protocolLink: result.sitePreview,
     dynamicLinks: result.affectedDomains,
+    cid: result.cid,
   };
 }
 

--- a/packages/browser-upload/tsup.config.ts
+++ b/packages/browser-upload/tsup.config.ts
@@ -4,9 +4,6 @@ const options: Options = {
   entryPoints: ["src/index.ts"],
   format: ["cjs"],
   dts: true,
-  env: {
-    SPHERON_API_URL: "https://api-v2.spheron.network",
-  },
 };
 
 export default options;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/core",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Shared core package for all sdk packages",
   "keywords": [
     "Storage",

--- a/packages/core/src/upload-manager.ts
+++ b/packages/core/src/upload-manager.ts
@@ -20,6 +20,7 @@ export interface UploadResult {
   bucketId: string;
   protocolLink: string;
   dynamicLinks: string[];
+  cid?: string;
 }
 
 class UploadManager {
@@ -119,6 +120,7 @@ class UploadManager {
     projectId: string;
     sitePreview: string;
     affectedDomains: string[];
+    cid: string;
   }> {
     try {
       const response = await axios.post<{
@@ -128,6 +130,7 @@ class UploadManager {
         projectId: string;
         sitePreview: string;
         affectedDomains: string[];
+        cid: string;
       }>(
         `${
           this.spheronApiUrl

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -35,7 +35,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@spheron/core": "1.0.3",
+    "@spheron/core": "1.0.6",
     "form-data": "^4.0.0",
     "multiformats": "^9.9.0"
   },

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -113,6 +113,7 @@ export class SpheronClient {
       bucketId: result.projectId,
       protocolLink: result.sitePreview,
       dynamicLinks: result.affectedDomains,
+      cid: result.cid,
     };
   }
 

--- a/packages/storage/tsup.config.ts
+++ b/packages/storage/tsup.config.ts
@@ -4,9 +4,6 @@ const options: Options = {
   entryPoints: ["src/index.ts"],
   format: ["cjs"],
   dts: true,
-  env: {
-    SPHERON_API_URL: "https://api-v2.spheron.network",
-  },
 };
 
 export default options;


### PR DESCRIPTION
API Changes: https://github.com/spheronFdn/upload-api/pull/75/files
PR Will:
- Add the `cid` to the return of the upload functions ( **browser + storage** ). CID exists only for filecoin and ipfs uploads.
- Remove unused variables from tsup configuration.

---
Will create the changes to the docs after approval