### PR TITLE
Update storage sdk to use the new storage organization endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5961,10 +5961,10 @@
     },
     "packages/browser-upload": {
       "name": "@spheron/browser-upload",
-      "version": "1.0.5",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spheron/core": "1.0.6",
+        "@spheron/core": "1.1.0",
         "@spheron/encryption": "1.0.0",
         "form-data": "^4.0.0",
         "jwt-decode": "^3.1.2"
@@ -5979,29 +5979,9 @@
         "typescript": "^4.9.5"
       }
     },
-    "packages/browser-upload/node_modules/@spheron/core": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.6.tgz",
-      "integrity": "sha512-kw/vtbrqiCOKuLon/gUUzgQOFFn401oQNqcbFjA4/KH1+1ucHTN/JPToNlkkngYcGUWpB3ZfdiYnmFCZBlUlFA==",
-      "dependencies": {
-        "axios": "1.1.2",
-        "eventsource": "^2.0.2",
-        "p-limit": "^3.0.0"
-      }
-    },
-    "packages/browser-upload/node_modules/axios": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
-      "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "packages/cli": {
       "name": "@spheron/cli",
-      "version": "1.0.13",
+      "version": "1.0.16",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6054,10 +6034,10 @@
     },
     "packages/compute": {
       "name": "@spheron/compute",
-      "version": "1.0.2",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spheron/core": "^1.0.8"
+        "@spheron/core": "^1.0.10"
       },
       "devDependencies": {
         "@types/node": "^18.13.0",
@@ -6071,7 +6051,7 @@
     },
     "packages/core": {
       "name": "@spheron/core",
-      "version": "1.0.8",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "1.1.2",
@@ -6116,7 +6096,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spheron/core": "1.0.8",
+        "@spheron/core": "1.0.9",
         "async-lock": "^1.4.0"
       },
       "devDependencies": {
@@ -6130,12 +6110,32 @@
         "typescript": "^4.9.5"
       }
     },
+    "packages/site/node_modules/@spheron/core": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.9.tgz",
+      "integrity": "sha512-FUuD7mlWPUotN+lpT7XfKRBxr5geYLonDi+I66+ECpJuwUS7EYE1k0QsGEXG4tu8OLcW1wxSlarNzcejh0DZIg==",
+      "dependencies": {
+        "axios": "1.1.2",
+        "eventsource": "^2.0.2",
+        "p-limit": "^3.0.0"
+      }
+    },
+    "packages/site/node_modules/axios": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
+      "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "packages/storage": {
       "name": "@spheron/storage",
-      "version": "1.0.19",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spheron/core": "1.0.8",
+        "@spheron/core": "1.1.0",
         "@spheron/encryption": "1.0.0",
         "form-data": "^4.0.0",
         "multiformats": "^9.9.0"
@@ -7785,7 +7785,7 @@
     "@spheron/browser-upload": {
       "version": "file:packages/browser-upload",
       "requires": {
-        "@spheron/core": "1.0.6",
+        "@spheron/core": "1.1.0",
         "@spheron/encryption": "1.0.0",
         "@types/node": "^18.13.0",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
@@ -7796,28 +7796,6 @@
         "prettier": "^2.8.3",
         "tsup": "^6.5.0",
         "typescript": "^4.9.5"
-      },
-      "dependencies": {
-        "@spheron/core": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.6.tgz",
-          "integrity": "sha512-kw/vtbrqiCOKuLon/gUUzgQOFFn401oQNqcbFjA4/KH1+1ucHTN/JPToNlkkngYcGUWpB3ZfdiYnmFCZBlUlFA==",
-          "requires": {
-            "axios": "1.1.2",
-            "eventsource": "^2.0.2",
-            "p-limit": "^3.0.0"
-          }
-        },
-        "axios": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
-          "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
-          "requires": {
-            "follow-redirects": "^1.15.0",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        }
       }
     },
     "@spheron/cli": {
@@ -7867,7 +7845,7 @@
     "@spheron/compute": {
       "version": "file:packages/compute",
       "requires": {
-        "@spheron/core": "^1.0.8",
+        "@spheron/core": "^1.0.10",
         "@types/node": "^18.13.0",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
@@ -7918,7 +7896,7 @@
     "@spheron/site": {
       "version": "file:packages/site",
       "requires": {
-        "@spheron/core": "1.0.8",
+        "@spheron/core": "1.0.9",
         "@types/async-lock": "^1.4.0",
         "@types/node": "^18.13.0",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
@@ -7928,12 +7906,34 @@
         "prettier": "^2.8.3",
         "tsup": "^6.5.0",
         "typescript": "^4.9.5"
+      },
+      "dependencies": {
+        "@spheron/core": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.9.tgz",
+          "integrity": "sha512-FUuD7mlWPUotN+lpT7XfKRBxr5geYLonDi+I66+ECpJuwUS7EYE1k0QsGEXG4tu8OLcW1wxSlarNzcejh0DZIg==",
+          "requires": {
+            "axios": "1.1.2",
+            "eventsource": "^2.0.2",
+            "p-limit": "^3.0.0"
+          }
+        },
+        "axios": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
+          "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
+          "requires": {
+            "follow-redirects": "^1.15.0",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        }
       }
     },
     "@spheron/storage": {
       "version": "file:packages/storage",
       "requires": {
-        "@spheron/core": "1.0.8",
+        "@spheron/core": "1.1.0",
         "@spheron/encryption": "1.0.0",
         "@types/node": "^18.13.0",
         "@typescript-eslint/eslint-plugin": "^5.51.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6021,6 +6021,37 @@
         "typescript": "^4.9.5"
       }
     },
+    "packages/cli/node_modules/@spheron/core": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.9.tgz",
+      "integrity": "sha512-FUuD7mlWPUotN+lpT7XfKRBxr5geYLonDi+I66+ECpJuwUS7EYE1k0QsGEXG4tu8OLcW1wxSlarNzcejh0DZIg==",
+      "dependencies": {
+        "axios": "1.1.2",
+        "eventsource": "^2.0.2",
+        "p-limit": "^3.0.0"
+      }
+    },
+    "packages/cli/node_modules/@spheron/core/node_modules/axios": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
+      "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "packages/cli/node_modules/@spheron/storage": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@spheron/storage/-/storage-1.0.19.tgz",
+      "integrity": "sha512-39Ao/3weWeXzGa1D8m7VRMZK2G6uw6c4HDQeguL0J/gLokYJd5tvGk/kp11UrFJyIj9OEc0tTkiL0zGNmuUELA==",
+      "dependencies": {
+        "@spheron/core": "1.0.9",
+        "@spheron/encryption": "1.0.0",
+        "form-data": "^4.0.0",
+        "multiformats": "^9.9.0"
+      }
+    },
     "packages/cli/node_modules/rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -6051,7 +6082,7 @@
     },
     "packages/core": {
       "name": "@spheron/core",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "1.1.2",
@@ -6135,7 +6166,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spheron/core": "1.1.0",
+        "@spheron/core": "2.0.0",
         "@spheron/encryption": "1.0.0",
         "form-data": "^4.0.0",
         "multiformats": "^9.9.0"
@@ -7832,6 +7863,39 @@
         "yargs": "^17.6.2"
       },
       "dependencies": {
+        "@spheron/core": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.9.tgz",
+          "integrity": "sha512-FUuD7mlWPUotN+lpT7XfKRBxr5geYLonDi+I66+ECpJuwUS7EYE1k0QsGEXG4tu8OLcW1wxSlarNzcejh0DZIg==",
+          "requires": {
+            "axios": "1.1.2",
+            "eventsource": "^2.0.2",
+            "p-limit": "^3.0.0"
+          },
+          "dependencies": {
+            "axios": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
+              "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
+              "requires": {
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+              }
+            }
+          }
+        },
+        "@spheron/storage": {
+          "version": "1.0.19",
+          "resolved": "https://registry.npmjs.org/@spheron/storage/-/storage-1.0.19.tgz",
+          "integrity": "sha512-39Ao/3weWeXzGa1D8m7VRMZK2G6uw6c4HDQeguL0J/gLokYJd5tvGk/kp11UrFJyIj9OEc0tTkiL0zGNmuUELA==",
+          "requires": {
+            "@spheron/core": "1.0.9",
+            "@spheron/encryption": "1.0.0",
+            "form-data": "^4.0.0",
+            "multiformats": "^9.9.0"
+          }
+        },
         "rimraf": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -7933,7 +7997,7 @@
     "@spheron/storage": {
       "version": "file:packages/storage",
       "requires": {
-        "@spheron/core": "1.1.0",
+        "@spheron/core": "2.0.0",
         "@spheron/encryption": "1.0.0",
         "@types/node": "^18.13.0",
         "@typescript-eslint/eslint-plugin": "^5.51.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5964,7 +5964,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spheron/core": "1.1.0",
+        "@spheron/core": "2.0.0",
         "@spheron/encryption": "1.0.0",
         "form-data": "^4.0.0",
         "jwt-decode": "^3.1.2"
@@ -6078,6 +6078,26 @@
         "prettier": "^2.8.3",
         "tsup": "^6.5.0",
         "typescript": "^4.9.5"
+      }
+    },
+    "packages/compute/node_modules/@spheron/core": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.10.tgz",
+      "integrity": "sha512-FaB1a+Sjf/1yo+yK/uXpAcg9DIag7ZNfc4CBiyGBVtgRGluiToXOCx+XJKrrdENqHOakAiA3yEeXIYp/bSdAoQ==",
+      "dependencies": {
+        "axios": "1.1.2",
+        "eventsource": "^2.0.2",
+        "p-limit": "^3.0.0"
+      }
+    },
+    "packages/compute/node_modules/axios": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
+      "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "packages/core": {
@@ -7816,7 +7836,7 @@
     "@spheron/browser-upload": {
       "version": "file:packages/browser-upload",
       "requires": {
-        "@spheron/core": "1.1.0",
+        "@spheron/core": "2.0.0",
         "@spheron/encryption": "1.0.0",
         "@types/node": "^18.13.0",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
@@ -7917,6 +7937,28 @@
         "prettier": "^2.8.3",
         "tsup": "^6.5.0",
         "typescript": "^4.9.5"
+      },
+      "dependencies": {
+        "@spheron/core": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.10.tgz",
+          "integrity": "sha512-FaB1a+Sjf/1yo+yK/uXpAcg9DIag7ZNfc4CBiyGBVtgRGluiToXOCx+XJKrrdENqHOakAiA3yEeXIYp/bSdAoQ==",
+          "requires": {
+            "axios": "1.1.2",
+            "eventsource": "^2.0.2",
+            "p-limit": "^3.0.0"
+          }
+        },
+        "axios": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
+          "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
+          "requires": {
+            "follow-redirects": "^1.15.0",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        }
       }
     },
     "@spheron/core": {

--- a/packages/browser-upload/README.md
+++ b/packages/browser-upload/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">  
   <a href="https://www.npmjs.com/package/@spheron/storage" target="_blank" rel="noreferrer">
-    <img src="https://img.shields.io/static/v1?label=npm&message=v1.0.5&color=green" />
+    <img src="https://img.shields.io/static/v1?label=npm&message=v2.0.0&color=green" />
   </a>
   <a href="https://github.com/spheronFdn/sdk/blob/main/LICENSE" target="_blank" rel="noreferrer">
     <img src="https://img.shields.io/static/v1?label=license&message=Apache%202.0&color=red" />

--- a/packages/browser-upload/package.json
+++ b/packages/browser-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/browser-upload",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Typescript library for uploading files or directory from the Browser to  IPFS, Filecoin or Arweave via Spheron",
   "keywords": [
     "Storage",

--- a/packages/browser-upload/package.json
+++ b/packages/browser-upload/package.json
@@ -35,7 +35,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@spheron/core": "1.0.6",
+    "@spheron/core": "1.1.0",
     "@spheron/encryption": "1.0.0",
     "form-data": "^4.0.0",
     "jwt-decode": "^3.1.2"

--- a/packages/browser-upload/package.json
+++ b/packages/browser-upload/package.json
@@ -35,7 +35,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@spheron/core": "1.1.0",
+    "@spheron/core": "2.0.0",
     "@spheron/encryption": "1.0.0",
     "form-data": "^4.0.0",
     "jwt-decode": "^3.1.2"

--- a/packages/browser-upload/package.json
+++ b/packages/browser-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/browser-upload",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Typescript library for uploading files or directory from the Browser to  IPFS, Filecoin or Arweave via Spheron",
   "keywords": [
     "Storage",

--- a/packages/browser-upload/src/index.ts
+++ b/packages/browser-upload/src/index.ts
@@ -17,6 +17,7 @@ async function upload(
   configuration: {
     token: string;
     onChunkUploaded?: (uploadedSize: number, totalSize: number) => void;
+    apiUrl?: string;
   }
 ): Promise<UploadResult> {
   let fileList: File[] = [];

--- a/packages/browser-upload/src/index.ts
+++ b/packages/browser-upload/src/index.ts
@@ -53,7 +53,7 @@ async function upload(
 
   let success = true;
   let caughtError: Error | undefined = undefined;
-  const uploadManager = new UploadManager();
+  const uploadManager = new UploadManager(configuration.apiUrl);
   try {
     const uploadPayloadsResult = await uploadManager.uploadPayloads(payloads, {
       uploadId,

--- a/packages/browser-upload/src/index.ts
+++ b/packages/browser-upload/src/index.ts
@@ -38,9 +38,9 @@ async function upload(
   const jwtPayload: {
     payloadSize: number;
     parallelUploadCount: number;
-    deploymentId: string;
+    uploadId: string;
   } = jwt_decode(configuration.token);
-  const uploadId = jwtPayload?.deploymentId ?? "";
+  const uploadId = jwtPayload?.uploadId ?? "";
   if (!uploadId) {
     throw new Error("The provided token is invalid.");
   }
@@ -55,7 +55,7 @@ async function upload(
   const uploadManager = new UploadManager();
   try {
     const uploadPayloadsResult = await uploadManager.uploadPayloads(payloads, {
-      deploymentId: uploadId,
+      uploadId,
       token: configuration.token,
       parallelUploadCount,
       onChunkUploaded: (uploadedSize: number) =>
@@ -70,7 +70,7 @@ async function upload(
     caughtError = error;
   }
 
-  const result = await uploadManager.finalizeUploadDeployment(
+  const result = await uploadManager.finalizeUpload(
     uploadId,
     success,
     configuration.token
@@ -85,10 +85,10 @@ async function upload(
   }
 
   return {
-    uploadId: result.deploymentId,
-    bucketId: result.projectId,
-    protocolLink: result.sitePreview,
-    dynamicLinks: result.affectedDomains,
+    uploadId: result.uploadId,
+    bucketId: result.bucketId,
+    protocolLink: result.protocolLink,
+    dynamicLinks: result.dynamicLinks,
     cid: result.cid,
   };
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/core",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Shared core package for all sdk packages",
   "keywords": [
     "Storage",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/core",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Shared core package for all sdk packages",
   "keywords": [
     "Storage",

--- a/packages/core/src/spheron-api/index.ts
+++ b/packages/core/src/spheron-api/index.ts
@@ -39,6 +39,7 @@ import {
   BucketStateEnum,
   Upload,
   BucketDomain,
+  BucketIpnsRecord,
 } from "./interfaces";
 import {
   CreateInstanceFromMarketplaceRequest,
@@ -998,7 +999,7 @@ class SpheronApi {
   //#region Bucket API
 
   async getBucket(bucketId: string): Promise<Bucket> {
-    return this.sendApiRequest<Bucket>(
+    return await this.sendApiRequest<Bucket>(
       HttpMethods.GET,
       `/v1/bucket/${bucketId}`
     );
@@ -1008,7 +1009,7 @@ class SpheronApi {
     bucketId: string,
     state: BucketStateEnum
   ): Promise<Bucket> {
-    return this.sendApiRequest<Bucket>(
+    return await this.sendApiRequest<Bucket>(
       HttpMethods.PATCH,
       `/v1/bucket/${bucketId}/state`,
       { state }
@@ -1018,7 +1019,7 @@ class SpheronApi {
   async getBucketDomains(
     bucketId: string
   ): Promise<{ domains: BucketDomain[] }> {
-    return this.sendApiRequest<{ domains: BucketDomain[] }>(
+    return await this.sendApiRequest<{ domains: BucketDomain[] }>(
       HttpMethods.GET,
       `/v1/bucket/${bucketId}/domains`
     );
@@ -1028,7 +1029,7 @@ class SpheronApi {
     bucketId: string,
     domainIdentifier: string
   ): Promise<{ domain: BucketDomain }> {
-    return this.sendApiRequest<{ domain: BucketDomain }>(
+    return await this.sendApiRequest<{ domain: BucketDomain }>(
       HttpMethods.GET,
       `/v1/bucket/${bucketId}/domains/${domainIdentifier}`
     );
@@ -1085,6 +1086,62 @@ class SpheronApi {
     await this.sendApiRequest(
       HttpMethods.DELETE,
       `/v1/bucket/${bucketId}/domains/${domainIdentifier}`
+    );
+  }
+
+  async getBucketIpnsRecords(
+    bucketId: string
+  ): Promise<{ ipnsRecords: BucketIpnsRecord[] }> {
+    return await this.sendApiRequest<{ ipnsRecords: BucketIpnsRecord[] }>(
+      HttpMethods.GET,
+      `/v1/bucket/${bucketId}/ipns-records`
+    );
+  }
+
+  async getBucketIpnsRecord(
+    bucketId: string,
+    ipnsRecordId: string
+  ): Promise<{ ipnsRecord: BucketIpnsRecord }> {
+    return await this.sendApiRequest<{ ipnsRecord: BucketIpnsRecord }>(
+      HttpMethods.GET,
+      `/v1/bucket/${bucketId}/ipns-records/${ipnsRecordId}`
+    );
+  }
+
+  async addBucketIpnsRecord(
+    bucketId: string,
+    uploadId: string
+  ): Promise<{ ipnsRecord: BucketIpnsRecord }> {
+    return await this.sendApiRequest<{ ipnsRecord: BucketIpnsRecord }>(
+      HttpMethods.POST,
+      `/v1/bucket/${bucketId}/ipns-records`,
+      {
+        uploadId,
+      }
+    );
+  }
+
+  async patchBucketIpnsRecord(
+    bucketId: string,
+    ipnsRecordId: string,
+    uploadId: string
+  ): Promise<{ ipnsRecord: BucketIpnsRecord }> {
+    return await this.sendApiRequest<{ ipnsRecord: BucketIpnsRecord }>(
+      HttpMethods.PATCH,
+      `/v1/bucket/${bucketId}/ipns-records/${ipnsRecordId}`,
+      {
+        uploadId,
+      }
+    );
+  }
+
+  async deleteBucketIpnsRecord(
+    bucketId: string,
+    ipnsRecordId: string
+  ): Promise<void> {
+    await this.sendApiRequest(
+      HttpMethods.DELETE,
+      `/v1/bucket/${bucketId}/ipns-records/${ipnsRecordId}`
     );
   }
 

--- a/packages/core/src/spheron-api/index.ts
+++ b/packages/core/src/spheron-api/index.ts
@@ -995,6 +995,62 @@ class SpheronApi {
 
   //#region Bucket API
 
+  async getOrganizationBuckets({
+    organizationId,
+    name,
+    state,
+    skip,
+    limit,
+  }: {
+    organizationId: string;
+    name?: string;
+    state?: BucketStateEnum;
+    skip: number;
+    limit: number;
+  }): Promise<{ buckets: Bucket[] }> {
+    if (!organizationId) {
+      throw new Error("Organization Id is not provided.");
+    }
+    if (skip < 0 || limit < 0) {
+      throw new Error(`Skip and Limit cannot be negative numbers.`);
+    }
+    return await this.sendApiRequest<{ buckets: Bucket[] }>(
+      HttpMethods.GET,
+      `/v1/organization/${organizationId}/buckets`,
+      null,
+      {
+        name: name ?? "",
+        state: state ?? "",
+        skip,
+        limit,
+      }
+    );
+  }
+
+  async getOrganizationBucketCount({
+    organizationId,
+    name,
+    state,
+  }: {
+    organizationId: string;
+    name?: string;
+    state?: BucketStateEnum;
+  }): Promise<{ count: number }> {
+    if (!organizationId) {
+      throw new Error("Organization Id is not provided.");
+    }
+
+    return await this.sendApiRequest<{ count: number }>(
+      HttpMethods.GET,
+      `/v1/organization/${organizationId}/buckets/count`,
+      null,
+      {
+        name: name ?? "",
+        state: state ?? "",
+      }
+    );
+  }
+
   async getBucket(bucketId: string): Promise<Bucket> {
     return await this.sendApiRequest<Bucket>(
       HttpMethods.GET,

--- a/packages/core/src/spheron-api/index.ts
+++ b/packages/core/src/spheron-api/index.ts
@@ -1223,6 +1223,25 @@ class SpheronApi {
     }>(HttpMethods.GET, `/v1/bucket/${bucketId}/uploads/count`);
   }
 
+  async migrateWebAppOrgToStorage(
+    webappOrganizationId: string,
+    storageOrganizationId: string
+  ): Promise<{
+    numberOfBuckets: number;
+    numberOfUploads: number;
+  }> {
+    return await this.sendApiRequest<{
+      numberOfBuckets: number;
+      numberOfUploads: number;
+    }>(
+      HttpMethods.POST,
+      `/v1/organization/${storageOrganizationId}/migrate-to-storage`,
+      {
+        webappOrganizationId,
+      }
+    );
+  }
+
   //#endregion Bucket API
 
   //#region Upload API

--- a/packages/core/src/spheron-api/index.ts
+++ b/packages/core/src/spheron-api/index.ts
@@ -35,6 +35,7 @@ import {
   MarketplaceApp,
   ComputeMachine,
   InstanceOrderLogs,
+  Bucket,
 } from "./interfaces";
 import {
   CreateInstanceFromMarketplaceRequest,
@@ -47,7 +48,9 @@ import {
 } from "./response-interfaces";
 
 class SpheronApi {
-  private readonly spheronApiUrl: string = "https://api-v2.spheron.network";
+  // private readonly spheronApiUrl: string = "https://api-v2.spheron.network";
+  private readonly spheronApiUrl: string = "http://localhost:8080";
+
   private readonly token: string;
 
   constructor(token: string, url?: string) {
@@ -984,6 +987,17 @@ class SpheronApi {
 
     return response;
   }
+
+  //#region Bucket API
+
+  async getBucket(bucketId: string): Promise<Bucket> {
+    return this.sendApiRequest<Bucket>(
+      HttpMethods.GET,
+      `/v1/bucket/${bucketId}`
+    );
+  }
+
+  //#endregion
 
   private async sendApiRequest<T>(
     method: HttpMethods,

--- a/packages/core/src/spheron-api/index.ts
+++ b/packages/core/src/spheron-api/index.ts
@@ -1223,7 +1223,7 @@ class SpheronApi {
     }>(HttpMethods.GET, `/v1/bucket/${bucketId}/uploads/count`);
   }
 
-  async migrateWebAppOrgToStorage(
+  async migrateStaticSiteOrgToStorage(
     webappOrganizationId: string,
     storageOrganizationId: string
   ): Promise<{

--- a/packages/core/src/spheron-api/index.ts
+++ b/packages/core/src/spheron-api/index.ts
@@ -36,6 +36,7 @@ import {
   ComputeMachine,
   InstanceOrderLogs,
   Bucket,
+  BucketStateEnum,
 } from "./interfaces";
 import {
   CreateInstanceFromMarketplaceRequest,
@@ -994,6 +995,17 @@ class SpheronApi {
     return this.sendApiRequest<Bucket>(
       HttpMethods.GET,
       `/v1/bucket/${bucketId}`
+    );
+  }
+
+  async updateBucketState(
+    bucketId: string,
+    state: BucketStateEnum
+  ): Promise<Bucket> {
+    return this.sendApiRequest<Bucket>(
+      HttpMethods.PATCH,
+      `/v1/bucket/${bucketId}/state`,
+      { state }
     );
   }
 

--- a/packages/core/src/spheron-api/index.ts
+++ b/packages/core/src/spheron-api/index.ts
@@ -330,7 +330,7 @@ class SpheronApi {
 
   async getOrganizationUsage(
     organizationId: string,
-    specialization: "wa-global" | "c-akash"
+    specialization: "wa-global" | "c-akash" | "storage"
   ): Promise<UsageWithLimitsWithSkynet> {
     const { usage } = await this.sendApiRequest<{
       usage: UsageWithLimitsWithSkynet;
@@ -1011,6 +1011,13 @@ class SpheronApi {
       HttpMethods.PATCH,
       `/v1/bucket/${bucketId}/state`,
       { state }
+    );
+  }
+
+  async getBucketDomains(bucketId: string): Promise<{ domains: Domain[] }> {
+    return this.sendApiRequest<{ domains: Domain[] }>(
+      HttpMethods.GET,
+      `/v1/bucket/${bucketId}/domains`
     );
   }
 

--- a/packages/core/src/spheron-api/index.ts
+++ b/packages/core/src/spheron-api/index.ts
@@ -1235,7 +1235,7 @@ class SpheronApi {
       numberOfUploads: number;
     }>(
       HttpMethods.POST,
-      `/v1/organization/${storageOrganizationId}/migrate-to-storage`,
+      `/v1/organization/${storageOrganizationId}/migrate-projects`,
       {
         webappOrganizationId,
       }

--- a/packages/core/src/spheron-api/index.ts
+++ b/packages/core/src/spheron-api/index.ts
@@ -38,6 +38,7 @@ import {
   Bucket,
   BucketStateEnum,
   Upload,
+  BucketDomain,
 } from "./interfaces";
 import {
   CreateInstanceFromMarketplaceRequest,
@@ -1014,10 +1015,76 @@ class SpheronApi {
     );
   }
 
-  async getBucketDomains(bucketId: string): Promise<{ domains: Domain[] }> {
-    return this.sendApiRequest<{ domains: Domain[] }>(
+  async getBucketDomains(
+    bucketId: string
+  ): Promise<{ domains: BucketDomain[] }> {
+    return this.sendApiRequest<{ domains: BucketDomain[] }>(
       HttpMethods.GET,
       `/v1/bucket/${bucketId}/domains`
+    );
+  }
+
+  async getBucketDomain(
+    bucketId: string,
+    domainIdentifier: string
+  ): Promise<{ domain: BucketDomain }> {
+    return this.sendApiRequest<{ domain: BucketDomain }>(
+      HttpMethods.GET,
+      `/v1/bucket/${bucketId}/domains/${domainIdentifier}`
+    );
+  }
+
+  async addBucketDomain(
+    bucketId: string,
+    options: {
+      link?: string;
+      type: DomainTypeEnum | string;
+      name: string;
+    }
+  ): Promise<{ domain: BucketDomain }> {
+    return await this.sendApiRequest<{ domain: BucketDomain }>(
+      HttpMethods.POST,
+      `/v1/bucket/${bucketId}/domains`,
+      options
+    );
+  }
+
+  async patchBucketDomain(
+    bucketId: string,
+    domainIdentifier: string,
+    options: {
+      link?: string;
+      name: string;
+    }
+  ): Promise<{ domain: BucketDomain }> {
+    return await this.sendApiRequest<{ domain: BucketDomain }>(
+      HttpMethods.PATCH,
+      `/v1/bucket/${bucketId}/domains/${domainIdentifier}`,
+      options
+    );
+  }
+
+  async verifyBucketDomain(
+    bucketId: string,
+    domainIdentifier: string
+  ): Promise<{ success: boolean; domain: BucketDomain }> {
+    return await this.sendApiRequest<{
+      success: boolean;
+      domain: BucketDomain;
+    }>(
+      HttpMethods.PATCH,
+      `/v1/bucket/${bucketId}/domains/${domainIdentifier}/verify`,
+      {}
+    );
+  }
+
+  async deleteBucketDomain(
+    bucketId: string,
+    domainIdentifier: string
+  ): Promise<void> {
+    await this.sendApiRequest(
+      HttpMethods.DELETE,
+      `/v1/bucket/${bucketId}/domains/${domainIdentifier}`
     );
   }
 

--- a/packages/core/src/spheron-api/index.ts
+++ b/packages/core/src/spheron-api/index.ts
@@ -52,16 +52,13 @@ import {
 } from "./response-interfaces";
 
 class SpheronApi {
-  // private readonly spheronApiUrl: string = "https://api-v2.spheron.network";
-  private readonly spheronApiUrl: string = "http://localhost:8080";
+  private readonly spheronApiUrl: string;
 
   private readonly token: string;
 
   constructor(token: string, url?: string) {
     this.token = token;
-    if (url) {
-      this.spheronApiUrl = url;
-    }
+    this.spheronApiUrl = url ?? "https://api-v2.spheron.network";
   }
 
   async getTokenScope(): Promise<TokenScope> {

--- a/packages/core/src/spheron-api/index.ts
+++ b/packages/core/src/spheron-api/index.ts
@@ -1035,7 +1035,18 @@ class SpheronApi {
     }>(HttpMethods.GET, `/v1/bucket/${bucketId}/uploads/count`);
   }
 
-  //#endregion
+  //#endregion Bucket API
+
+  //#region Upload API
+
+  async getUpload(uploadId: string): Promise<Upload> {
+    const { upload } = await this.sendApiRequest<{
+      upload: Upload;
+    }>(HttpMethods.GET, `/v1/upload/${uploadId}`);
+    return upload;
+  }
+
+  //#region Upload API
 
   private async sendApiRequest<T>(
     method: HttpMethods,

--- a/packages/core/src/spheron-api/index.ts
+++ b/packages/core/src/spheron-api/index.ts
@@ -37,6 +37,7 @@ import {
   InstanceOrderLogs,
   Bucket,
   BucketStateEnum,
+  Upload,
 } from "./interfaces";
 import {
   CreateInstanceFromMarketplaceRequest,
@@ -1007,6 +1008,31 @@ class SpheronApi {
       `/v1/bucket/${bucketId}/state`,
       { state }
     );
+  }
+
+  async getBucketUploads(
+    bucketId: string,
+    options: {
+      skip: number;
+      limit: number;
+    }
+  ): Promise<{ uploads: Upload[] }> {
+    if (options.skip < 0 || options.limit < 0) {
+      throw new Error(`Skip and Limit cannot be negative numbers.`);
+    }
+    const uploads = await this.sendApiRequest<Upload[]>(
+      HttpMethods.GET,
+      `/v1/bucket/${bucketId}/uploads?skip=${options.skip}&limit=${options.limit}`
+    );
+    return { uploads };
+  }
+
+  async getBucketUploadCount(bucketId: string): Promise<{
+    count: number;
+  }> {
+    return await this.sendApiRequest<{
+      count: number;
+    }>(HttpMethods.GET, `/v1/bucket/${bucketId}/uploads/count`);
   }
 
   //#endregion

--- a/packages/core/src/spheron-api/interfaces.ts
+++ b/packages/core/src/spheron-api/interfaces.ts
@@ -517,11 +517,11 @@ interface BucketIpnsRecord {
   keyName: string;
   keyId: string;
   ipnsLink: string;
-  upload: Upload;
   bucket: string;
   targetCid: string;
   createdAt: Date;
   updatedAt: Date;
+  memoryUsed: number;
 }
 
 enum UploadStatusEnum {

--- a/packages/core/src/spheron-api/interfaces.ts
+++ b/packages/core/src/spheron-api/interfaces.ts
@@ -483,6 +483,19 @@ interface ComputeMachine {
   topupThreashold: number;
 }
 
+enum BucketStateEnum {
+  MAINTAINED = "MAINTAINED",
+  ARCHIVED = "ARCHIVED",
+}
+
+interface Bucket extends Document {
+  _id: string;
+  name: string;
+  organization: string;
+  createdBy: string;
+  state: BucketStateEnum;
+}
+
 export {
   TokenScope,
   Project,
@@ -519,4 +532,6 @@ export {
   HealthCheck,
   MachineImageType,
   InstanceOrderLogs,
+  Bucket,
+  BucketStateEnum,
 };

--- a/packages/core/src/spheron-api/interfaces.ts
+++ b/packages/core/src/spheron-api/interfaces.ts
@@ -509,6 +509,18 @@ interface BucketDomain {
   type: DomainTypeEnum;
 }
 
+interface BucketIpnsRecord {
+  _id: string;
+  keyName: string;
+  keyId: string;
+  ipnsLink: string;
+  upload: Upload;
+  bucket: string;
+  targetCid: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 enum UploadStatusEnum {
   IN_PROGRESS = "InProgress",
   CANCELED = "Canceled",
@@ -577,4 +589,5 @@ export {
   Upload,
   UploadedFile,
   BucketDomain,
+  BucketIpnsRecord,
 };

--- a/packages/core/src/spheron-api/interfaces.ts
+++ b/packages/core/src/spheron-api/interfaces.ts
@@ -197,6 +197,10 @@ interface UsageWithLimits {
   passwordProtectionLimit?: number;
   usedParallelUploads?: number;
   parallelUploadsLimit?: number;
+  usedStorageFilecoin?: number;
+  storageFilecoinLimit?: number;
+  usedImageOptimizations?: number;
+  imageOptimizationsLimit?: number;
 }
 
 interface UsageWithLimitsWithSkynet extends UsageWithLimits {
@@ -502,12 +506,19 @@ enum UploadStatusEnum {
   UPLOADED = "Uploaded",
   FAILED = "Failed",
   TIMED_OUT = "TimedOut",
+  PINNED = "Pinned",
+  UNPINNED = "Unpinned",
+}
+
+interface UploadedFile {
+  fileName: string;
+  fileSize: number;
 }
 
 interface Upload {
   _id: string;
   protocolLink: string;
-  uploadDirectory: string[];
+  uploadDirectory: UploadedFile[];
   status: UploadStatusEnum;
   memoryUsed: number;
   bucket: string;
@@ -555,4 +566,5 @@ export {
   BucketStateEnum,
   UploadStatusEnum,
   Upload,
+  UploadedFile,
 };

--- a/packages/core/src/spheron-api/interfaces.ts
+++ b/packages/core/src/spheron-api/interfaces.ts
@@ -496,6 +496,25 @@ interface Bucket extends Document {
   state: BucketStateEnum;
 }
 
+enum UploadStatusEnum {
+  IN_PROGRESS = "InProgress",
+  CANCELED = "Canceled",
+  UPLOADED = "Uploaded",
+  FAILED = "Failed",
+  TIMED_OUT = "TimedOut",
+}
+
+interface Upload {
+  _id: string;
+  protocolLink: string;
+  uploadDirectory: string[];
+  status: UploadStatusEnum;
+  memoryUsed: number;
+  bucket: string;
+  uploadInitiator: string;
+  protocol: ProtocolEnum;
+}
+
 export {
   TokenScope,
   Project,
@@ -534,4 +553,6 @@ export {
   InstanceOrderLogs,
   Bucket,
   BucketStateEnum,
+  UploadStatusEnum,
+  Upload,
 };

--- a/packages/core/src/spheron-api/interfaces.ts
+++ b/packages/core/src/spheron-api/interfaces.ts
@@ -201,6 +201,9 @@ interface UsageWithLimits {
   storageFilecoinLimit?: number;
   usedImageOptimizations?: number;
   imageOptimizationsLimit?: number;
+  usedIpfsBandwidth: number;
+  ipfsBandwidthLimit?: number;
+  usedIpfsNumberOfRequests?: number;
 }
 
 interface UsageWithLimitsWithSkynet extends UsageWithLimits {

--- a/packages/core/src/spheron-api/interfaces.ts
+++ b/packages/core/src/spheron-api/interfaces.ts
@@ -492,12 +492,21 @@ enum BucketStateEnum {
   ARCHIVED = "ARCHIVED",
 }
 
-interface Bucket extends Document {
+interface Bucket {
   _id: string;
   name: string;
   organization: string;
   createdBy: string;
   state: BucketStateEnum;
+}
+
+interface BucketDomain {
+  _id: string;
+  name: string;
+  link: string;
+  verified: boolean;
+  bucketId: string;
+  type: DomainTypeEnum;
 }
 
 enum UploadStatusEnum {
@@ -567,4 +576,5 @@ export {
   UploadStatusEnum,
   Upload,
   UploadedFile,
+  BucketDomain,
 };

--- a/packages/core/src/upload-manager.ts
+++ b/packages/core/src/upload-manager.ts
@@ -94,8 +94,6 @@ class UploadManager {
         url += `&organization=${configuration.organizationId}`;
       }
 
-      console.log(url);
-
       const response = await axios.post<{
         uploadId: string;
         bucketId: string;

--- a/packages/core/src/upload-manager.ts
+++ b/packages/core/src/upload-manager.ts
@@ -28,35 +28,35 @@ class UploadManager {
   // private readonly spheronApiUrl: string = "https://api-v2.spheron.network";
   private readonly spheronApiUrl: string = "http://localhost:8002";
 
-  public async initiateDeployment(configuration: {
+  public async initiateUpload(configuration: {
     protocol: ProtocolEnum;
     name: string;
     organizationId?: string;
     token: string;
-    createSingleDeploymentToken?: boolean;
+    createSingleUseToken?: boolean;
   }): Promise<{
-    deploymentId: string;
+    uploadId: string;
     parallelUploadCount: number;
     payloadSize: number;
-    singleDeploymentToken?: string;
+    singleUseToken?: string;
   }> {
     try {
       this.validateUploadConfiguration(configuration);
 
-      let url = `${this.spheronApiUrl}/v1/upload-deployment?protocol=${configuration.protocol}&project=${configuration.name}`;
+      let url = `${this.spheronApiUrl}/v1/upload/initiate?protocol=${configuration.protocol}&bucket=${configuration.name}`;
 
       if (configuration.organizationId) {
         url += `&organization=${configuration.organizationId}`;
       }
 
-      if (configuration.createSingleDeploymentToken) {
-        url += `&create_single_deployment_token=${configuration.createSingleDeploymentToken}`;
+      if (configuration.createSingleUseToken) {
+        url += `&create_single_use_token=${configuration.createSingleUseToken}`;
       }
 
       const response = await axios.post<{
-        deploymentId: string;
+        uploadId: string;
         parallelUploadCount: number;
-        singleDeploymentToken?: string;
+        singleUseToken?: string;
         payloadSize: number;
       }>(
         url,
@@ -134,7 +134,7 @@ class UploadManager {
   public async uploadPayloads(
     payloads: FormData[],
     configuration: {
-      deploymentId: string;
+      uploadId: string;
       token: string;
       parallelUploadCount: number;
       onChunkUploaded?: (uploadedSize: number) => void;
@@ -143,13 +143,13 @@ class UploadManager {
     let errorMessage = "";
     const limit = pLimit(configuration.parallelUploadCount);
 
-    const uploadPayload = async (payload: FormData, deploymentId: string) => {
+    const uploadPayload = async (payload: FormData, uploadId: string) => {
       try {
         if (errorMessage) {
           return;
         }
         const { data } = await axios.post<{ uploadSize: number }>(
-          `${this.spheronApiUrl}/v1/upload-deployment/${deploymentId}/data`,
+          `${this.spheronApiUrl}/v1/upload/${uploadId}/data`,
           payload,
           this.getAxiosRequestConfig(configuration.token)
         );
@@ -162,38 +162,36 @@ class UploadManager {
 
     await Promise.all(
       payloads.map((payload) =>
-        limit(() => uploadPayload(payload, configuration.deploymentId))
+        limit(() => uploadPayload(payload, configuration.uploadId))
       )
     );
     return { success: !errorMessage, errorMessage: errorMessage };
   }
 
-  public async finalizeUploadDeployment(
-    deploymentId: string,
+  public async finalizeUpload(
+    uploadId: string,
     upload: boolean,
     token: string
   ): Promise<{
     success: boolean;
     message: string;
-    deploymentId: string;
-    projectId: string;
-    sitePreview: string;
-    affectedDomains: string[];
+    uploadId: string;
+    bucketId: string;
+    protocolLink: string;
+    dynamicLinks: string[];
     cid: string;
   }> {
     try {
       const response = await axios.post<{
         success: boolean;
         message: string;
-        deploymentId: string;
-        projectId: string;
-        sitePreview: string;
-        affectedDomains: string[];
+        uploadId: string;
+        bucketId: string;
+        protocolLink: string;
+        dynamicLinks: string[];
         cid: string;
       }>(
-        `${
-          this.spheronApiUrl
-        }/v1/upload-deployment/${deploymentId}/finish?action=${
+        `${this.spheronApiUrl}/v1/upload/${uploadId}/finish?action=${
           upload ? "UPLOAD" : "CANCEL"
         }`,
         {},

--- a/packages/core/src/upload-manager.ts
+++ b/packages/core/src/upload-manager.ts
@@ -79,10 +79,10 @@ class UploadManager {
     token: string;
     cid: string;
   }): Promise<{
-    deploymentId: string;
-    projectId: string;
-    sitePreview: string;
-    affectedDomains: string[];
+    uploadId: string;
+    bucketId: string;
+    protocolLink: string;
+    dynamicLinks: string[];
   }> {
     try {
       if (!configuration.name) {
@@ -97,10 +97,10 @@ class UploadManager {
       console.log(url);
 
       const response = await axios.post<{
-        deploymentId: string;
-        projectId: string;
-        sitePreview: string;
-        affectedDomains: string[];
+        uploadId: string;
+        bucketId: string;
+        protocolLink: string;
+        dynamicLinks: string[];
       }>(
         url,
         {},

--- a/packages/core/src/upload-manager.ts
+++ b/packages/core/src/upload-manager.ts
@@ -120,7 +120,7 @@ class UploadManager {
       if (!CID) {
         throw new Error("CID is not provided.");
       }
-      const url = `${this.spheronApiUrl}/v1/ipfs/pins/${CID}/status`;
+      const url = `${this.spheronApiUrl}/v2/ipfs/pins/${CID}/status`;
       const response = await axios.get<{ pinStatus: PinStatus }>(url);
       return response.data;
     } catch (error) {

--- a/packages/core/src/upload-manager.ts
+++ b/packages/core/src/upload-manager.ts
@@ -25,8 +25,11 @@ export interface UploadResult {
 }
 
 class UploadManager {
-  // private readonly spheronApiUrl: string = "https://api-v2.spheron.network";
-  private readonly spheronApiUrl: string = "http://localhost:8002";
+  private readonly spheronApiUrl: string;
+
+  constructor(apiUrl?: string) {
+    this.spheronApiUrl = apiUrl ?? "https://api-v2.spheron.network";
+  }
 
   public async initiateUpload(configuration: {
     protocol: ProtocolEnum;

--- a/packages/core/src/upload-manager.ts
+++ b/packages/core/src/upload-manager.ts
@@ -25,7 +25,8 @@ export interface UploadResult {
 }
 
 class UploadManager {
-  private readonly spheronApiUrl: string = "https://api-v2.spheron.network";
+  // private readonly spheronApiUrl: string = "https://api-v2.spheron.network";
+  private readonly spheronApiUrl: string = "http://localhost:8002";
 
   public async initiateDeployment(configuration: {
     protocol: ProtocolEnum;
@@ -87,11 +88,13 @@ class UploadManager {
       if (!configuration.name) {
         throw new Error("Bucket name is not provided.");
       }
-      let url = `${this.spheronApiUrl}/v1/ipfs/pin/${configuration.cid}?project=${configuration.name}`;
+      let url = `${this.spheronApiUrl}/v2/ipfs/pin/${configuration.cid}?bucket=${configuration.name}`;
 
       if (configuration.organizationId) {
         url += `&organization=${configuration.organizationId}`;
       }
+
+      console.log(url);
 
       const response = await axios.post<{
         deploymentId: string;
@@ -122,7 +125,6 @@ class UploadManager {
       const url = `${this.spheronApiUrl}/v1/ipfs/pins/${CID}/status`;
       const response = await axios.get<{ pinStatus: PinStatus }>(url);
       return response.data;
-
     } catch (error) {
       const errorMessage = error?.response?.data?.message || error?.message;
       throw new Error(errorMessage);

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">  
   <a href="https://www.npmjs.com/package/@spheron/storage" target="_blank" rel="noreferrer">
-    <img src="https://img.shields.io/static/v1?label=npm&message=v1.0.19&color=green" />
+    <img src="https://img.shields.io/static/v1?label=npm&message=v2.0.0&color=green" />
   </a>
   <a href="https://github.com/spheronFdn/sdk/blob/main/LICENSE" target="_blank" rel="noreferrer">
     <img src="https://img.shields.io/static/v1?label=license&message=Apache%202.0&color=red" />
@@ -64,61 +64,13 @@ const { uploadId, bucketId, protocolLink, dynamicLinks, cid } =
     - `dynamicLinks` - are domains that you have setup for your bucket. When you upload new data to the same bucket, the domains will point to the new uploaded data.
     - `cid` - the CID of the uploaded data. Only exists for IPFS and Filecoin protocols.
 
-### IPNS Example
-
-In the example below you can see how to publish an upload to IPNS, update IPNS to another upload id and get all IPNS names for an organization.
-
-```js
-import { SpheronClient, ProtocolEnum } from "@spheron/storage";
-
-const client = new SpheronClient({ token });
-let currentlyUploaded = 0;
-const { uploadId, bucketId, protocolLink, dynamicLinks, cid } =
-  await client.upload(filePath, {
-    protocol: ProtocolEnum.IPFS, // Only works with IPFS and Filecoin uploads
-    name,
-    onUploadInitiated: (uploadId) => {
-      console.log(`Upload with id ${uploadId} started...`);
-    },
-    onChunkUploaded: (uploadedSize, totalSize) => {
-      currentlyUploaded += uploadedSize;
-      console.log(`Uploaded ${currentlyUploaded} of ${totalSize} Bytes.`);
-    },
-  });
-
-// Publish Upload to IPNS
-const ipnsData: IPNSName = await client.publishIPNS(uploadId);
-
-// Upload second file to Spheron
-const uploadIdTwo = await client.upload(filePath2, { ...uploadDetails });
-
-// Update IPNS Name to point to another upload
-const ipnsData: IPNSName = await client.updateIPNSName(
-  ipnsData.id,
-  uploadIdTwo
-);
-
-// Get all published IPNS Names for organization
-const orgIPNSNames: IPNSName[] = await client.getIPNSNamesForOrganization(
-  organizationId
-);
-```
-
-- Function `publishIPNS` has one parameter `client.upload(uploadId);`
-  - `uploadId` - the upload id of file uploaded using Spheron SDK
-- Function `updateIPNSName` has two parameters `client.updateIPNSName(ipnsNameId, uploadId);`
-  - `ipnsNameId` - the IPNS name id of a previously published upload
-  - `uploadId` - the new upload id you want IPNS Name to point to.
-- Function `orgIPNSNames` has one parameter `client.upload(organizationId);`
-  - `organizationId` - your organization id
-
 ---
 
-### For more information about the Storage SDK, check out the [DOCS](https://docs.spheron.network/sdk/storage/)
+### For more information about the Storage SDK, check out the [DOCS](https://docs.spheron.network/sdk/storage-v2/)
 
 ## Access Token
 
-To create the `token` that is used with the `SpheronClient`, follow the instructions in the [DOCS](https://docs.spheron.network/rest-api/#creating-an-access-token). When you are creating the tokens, please choose **web app** type in the dashboard.
+To create the `token` that is used with the `SpheronClient`, follow the instructions in the [DOCS](https://docs.spheron.network/rest-api/#creating-an-access-token). When you are creating the tokens, please choose **Storage** type in the dashboard.
 
 ## Notes
 

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -35,7 +35,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@spheron/core": "1.1.0",
+    "@spheron/core": "2.0.0",
     "@spheron/encryption": "1.0.0",
     "form-data": "^4.0.0",
     "multiformats": "^9.9.0"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/storage",
-  "version": "1.0.19",
+  "version": "2.0.0",
   "description": "Typescript library for uploading files or directory to  IPFS, Filecoin or Arweave via Spheron",
   "keywords": [
     "Storage",
@@ -35,7 +35,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@spheron/core": "1.0.9",
+    "@spheron/core": "1.1.0",
     "@spheron/encryption": "1.0.0",
     "form-data": "^4.0.0",
     "multiformats": "^9.9.0"

--- a/packages/storage/src/bucket-manager/index.ts
+++ b/packages/storage/src/bucket-manager/index.ts
@@ -126,8 +126,8 @@ class BucketManager {
   }
 
   async getUpload(uploadId: string): Promise<Upload> {
-    const deployment = await this.spheronApi.getDeployment(uploadId);
-    return this.mapDeploymentToUpload(deployment);
+    const upload = await this.spheronApi.getUpload(uploadId);
+    return this.mapCoreUpload(upload);
   }
 
   private mapCoreBucket(bucket: CoreBucket): Bucket {
@@ -159,18 +159,6 @@ class BucketManager {
       memoryUsed: upload.memoryUsed,
       bucketId: upload.bucket,
       protocol: upload.protocol,
-    };
-  }
-
-  private mapDeploymentToUpload(deployment: Deployment): Upload {
-    return {
-      id: deployment._id,
-      protocolLink: deployment.sitePreview,
-      uploadDirectory: deployment.buildDirectory,
-      status: deployment.status as unknown as UploadStatusEnum,
-      memoryUsed: deployment.memoryUsed,
-      bucketId: deployment.project?._id ?? deployment.project,
-      protocol: deployment.protocol,
     };
   }
 }

--- a/packages/storage/src/bucket-manager/index.ts
+++ b/packages/storage/src/bucket-manager/index.ts
@@ -11,7 +11,7 @@ import {
   BucketStateEnum,
   UploadStatusEnum,
 } from "./interfaces";
-import { Deployment, Domain as ProjectDomain } from "@spheron/core";
+import { Domain as ProjectDomain } from "@spheron/core";
 
 class BucketManager {
   private readonly spheronApi: SpheronApi;

--- a/packages/storage/src/bucket-manager/index.ts
+++ b/packages/storage/src/bucket-manager/index.ts
@@ -11,7 +11,7 @@ import {
   BucketStateEnum,
   UploadStatusEnum,
 } from "./interfaces";
-import { Domain as ProjectDomain } from "@spheron/core";
+import { BucketDomain as CoreBucketDomain } from "@spheron/core";
 
 class BucketManager {
   private readonly spheronApi: SpheronApi;
@@ -26,19 +26,19 @@ class BucketManager {
   }
 
   async getBucketDomains(bucketId: string): Promise<Domain[]> {
-    const { domains } = await this.spheronApi.getProjectDomains(bucketId);
-    return domains.map((x) => this.mapProjectDomainToBucketDomain(x));
+    const { domains } = await this.spheronApi.getBucketDomains(bucketId);
+    return domains.map((x) => this.mapCoreBucketDomains(x));
   }
 
   async getBucketDomain(
     bucketId: string,
     domainIdentifier: string
   ): Promise<Domain> {
-    const { domain } = await this.spheronApi.getProjectDomain(
+    const { domain } = await this.spheronApi.getBucketDomain(
       bucketId,
       domainIdentifier
     );
-    return this.mapProjectDomainToBucketDomain(domain);
+    return this.mapCoreBucketDomains(domain);
   }
 
   async updateBucketDomain(
@@ -49,30 +49,30 @@ class BucketManager {
       name: string;
     }
   ): Promise<Domain> {
-    const { domain } = await this.spheronApi.patchProjectDomain(
+    const { domain } = await this.spheronApi.patchBucketDomain(
       bucketId,
       domainIdentifier,
-      { ...options, deploymentEnvironments: [] }
+      { ...options }
     );
-    return this.mapProjectDomainToBucketDomain(domain);
+    return this.mapCoreBucketDomains(domain);
   }
 
   async verifyBucketDomain(
     bucketId: string,
     domainIdentifier: string
   ): Promise<Domain> {
-    const { domain } = await this.spheronApi.verifyProjectDomain(
+    const { domain } = await this.spheronApi.verifyBucketDomain(
       bucketId,
       domainIdentifier
     );
-    return this.mapProjectDomainToBucketDomain(domain);
+    return this.mapCoreBucketDomains(domain);
   }
 
   async deleteBucketDomain(
     bucketId: string,
     domainIdentifier: string
   ): Promise<void> {
-    await this.spheronApi.deleteProjectDomain(bucketId, domainIdentifier);
+    await this.spheronApi.deleteBucketDomain(bucketId, domainIdentifier);
   }
 
   async addBucketDomain(
@@ -83,11 +83,10 @@ class BucketManager {
       name: string;
     }
   ): Promise<Domain> {
-    const { domain } = await this.spheronApi.addProjectDomain(bucketId, {
+    const { domain } = await this.spheronApi.addBucketDomain(bucketId, {
       ...options,
-      deploymentEnvironments: [],
     });
-    return this.mapProjectDomainToBucketDomain(domain);
+    return this.mapCoreBucketDomains(domain);
   }
 
   async getBucketUploads(
@@ -139,13 +138,13 @@ class BucketManager {
     };
   }
 
-  private mapProjectDomainToBucketDomain(domain: ProjectDomain): Domain {
+  private mapCoreBucketDomains(domain: CoreBucketDomain): Domain {
     return {
       id: domain._id,
       name: domain.name,
       link: domain.link,
       verified: domain.verified,
-      bucketId: domain.projectId,
+      bucketId: domain.bucketId,
       type: domain.type,
     };
   }

--- a/packages/storage/src/bucket-manager/index.ts
+++ b/packages/storage/src/bucket-manager/index.ts
@@ -1,8 +1,8 @@
 import {
   DomainTypeEnum,
   ProjectStateEnum,
-  ProjectTypeEnum,
   SpheronApi,
+  Bucket as CoreBucket,
 } from "@spheron/core";
 import {
   Bucket,
@@ -11,7 +11,7 @@ import {
   BucketStateEnum,
   UploadStatusEnum,
 } from "./interfaces";
-import { Deployment, Domain as ProjectDomain, Project } from "@spheron/core";
+import { Deployment, Domain as ProjectDomain } from "@spheron/core";
 
 class BucketManager {
   private readonly spheronApi: SpheronApi;
@@ -21,11 +21,8 @@ class BucketManager {
   }
 
   async getBucket(bucketId: string): Promise<Bucket> {
-    const project = await this.spheronApi.getProject(bucketId);
-    if (project.type !== ProjectTypeEnum.UPLOAD) {
-      throw new Error(`Project with id '${bucketId}' is not a bucket.`);
-    }
-    return this.mapProjectToBucket(project);
+    const bucket = await this.spheronApi.getBucket(bucketId);
+    return this.mapCoreBucket(bucket);
   }
 
   async getBucketDomains(bucketId: string): Promise<Domain[]> {
@@ -142,15 +139,12 @@ class BucketManager {
     return this.mapDeploymentToUpload(deployment);
   }
 
-  private mapProjectToBucket(project: Project): Bucket {
+  private mapCoreBucket(bucket: CoreBucket): Bucket {
     return {
-      id: project._id,
-      name: project.name,
-      organizationId: project.organization,
-      state: project.state,
-      domains: project.domains?.map((x) =>
-        this.mapProjectDomainToBucketDomain(x)
-      ),
+      id: bucket._id,
+      name: bucket.name,
+      organizationId: bucket.organization,
+      state: bucket.state,
     };
   }
 

--- a/packages/storage/src/bucket-manager/index.ts
+++ b/packages/storage/src/bucket-manager/index.ts
@@ -141,10 +141,9 @@ class BucketManager {
     return uploads.map((x) => this.mapCoreUpload(x));
   }
 
-  async getBucketUploadCount(bucketId: string): Promise<{
-    count: number;
-  }> {
-    return await this.spheronApi.getBucketUploadCount(bucketId);
+  async getBucketUploadCount(bucketId: string): Promise<number> {
+    const { count } = await this.spheronApi.getBucketUploadCount(bucketId);
+    return count;
   }
 
   async archiveBucket(bucketId: string): Promise<void> {
@@ -249,10 +248,10 @@ class BucketManager {
       id: ipnsRecord._id,
       ipnsHash: ipnsRecord.keyId,
       ipnsLink: ipnsRecord.ipnsLink,
-      publishedUploadId: ipnsRecord.upload._id ?? ipnsRecord.upload,
       bucketId: ipnsRecord.bucket,
       createdAt: ipnsRecord.createdAt,
       updatedAt: ipnsRecord.updatedAt,
+      memoryUsed: ipnsRecord.memoryUsed,
     };
   }
 }

--- a/packages/storage/src/bucket-manager/index.ts
+++ b/packages/storage/src/bucket-manager/index.ts
@@ -10,8 +10,12 @@ import {
   Upload,
   BucketStateEnum,
   UploadStatusEnum,
+  IpnsRecord,
 } from "./interfaces";
-import { BucketDomain as CoreBucketDomain } from "@spheron/core";
+import {
+  BucketDomain as CoreBucketDomain,
+  BucketIpnsRecord as CoreBucketIpnsRecord,
+} from "@spheron/core";
 
 class BucketManager {
   private readonly spheronApi: SpheronApi;
@@ -129,6 +133,55 @@ class BucketManager {
     return this.mapCoreUpload(upload);
   }
 
+  async getBucketIpnsRecords(bucketId: string): Promise<IpnsRecord[]> {
+    const { ipnsRecords } = await this.spheronApi.getBucketIpnsRecords(
+      bucketId
+    );
+    return ipnsRecords.map((x) => this.mapCoreIpnsRecord(x));
+  }
+
+  async getBucketIpnsRecord(
+    bucketId: string,
+    ipnsRecordId: string
+  ): Promise<IpnsRecord> {
+    const { ipnsRecord } = await this.spheronApi.getBucketIpnsRecord(
+      bucketId,
+      ipnsRecordId
+    );
+    return this.mapCoreIpnsRecord(ipnsRecord);
+  }
+
+  async addBucketIpnsRecord(
+    bucketId: string,
+    uploadId: string
+  ): Promise<IpnsRecord> {
+    const { ipnsRecord } = await this.spheronApi.addBucketIpnsRecord(
+      bucketId,
+      uploadId
+    );
+    return this.mapCoreIpnsRecord(ipnsRecord);
+  }
+
+  async updateBucketIpnsRecord(
+    bucketId: string,
+    ipnsRecordId: string,
+    uploadId: string
+  ): Promise<IpnsRecord> {
+    const { ipnsRecord } = await this.spheronApi.patchBucketIpnsRecord(
+      bucketId,
+      ipnsRecordId,
+      uploadId
+    );
+    return this.mapCoreIpnsRecord(ipnsRecord);
+  }
+
+  async deleteBucketIpnsRecord(
+    bucketId: string,
+    ipnsRecordId: string
+  ): Promise<void> {
+    await this.spheronApi.deleteBucketIpnsRecord(bucketId, ipnsRecordId);
+  }
+
   private mapCoreBucket(bucket: CoreBucket): Bucket {
     return {
       id: bucket._id,
@@ -158,6 +211,18 @@ class BucketManager {
       memoryUsed: upload.memoryUsed,
       bucketId: upload.bucket,
       protocol: upload.protocol,
+    };
+  }
+
+  private mapCoreIpnsRecord(ipnsRecord: CoreBucketIpnsRecord): IpnsRecord {
+    return {
+      id: ipnsRecord._id,
+      ipnsHash: ipnsRecord.keyId,
+      ipnsLink: ipnsRecord.ipnsLink,
+      publishedUploadId: ipnsRecord.upload._id ?? ipnsRecord.upload,
+      bucketId: ipnsRecord.bucket,
+      createdAt: ipnsRecord.createdAt,
+      updatedAt: ipnsRecord.updatedAt,
     };
   }
 }

--- a/packages/storage/src/bucket-manager/index.ts
+++ b/packages/storage/src/bucket-manager/index.ts
@@ -1,6 +1,5 @@
 import {
   DomainTypeEnum,
-  ProjectStateEnum,
   SpheronApi,
   Bucket as CoreBucket,
 } from "@spheron/core";
@@ -121,16 +120,13 @@ class BucketManager {
   }
 
   async archiveBucket(bucketId: string): Promise<void> {
-    await this.spheronApi.updateProjectState(
-      bucketId,
-      ProjectStateEnum.ARCHIVED
-    );
+    await this.spheronApi.updateBucketState(bucketId, BucketStateEnum.ARCHIVED);
   }
 
   async unarchiveBucket(bucketId: string): Promise<void> {
-    await this.spheronApi.updateProjectState(
+    await this.spheronApi.updateBucketState(
       bucketId,
-      ProjectStateEnum.MAINTAINED
+      BucketStateEnum.MAINTAINED
     );
   }
 

--- a/packages/storage/src/bucket-manager/index.ts
+++ b/packages/storage/src/bucket-manager/index.ts
@@ -24,6 +24,36 @@ class BucketManager {
     this.spheronApi = spheronApi;
   }
 
+  async getOrganizationBuckets(
+    organizationId: string,
+    options: {
+      name?: string;
+      state?: BucketStateEnum;
+      skip: number;
+      limit: number;
+    }
+  ): Promise<Bucket[]> {
+    const { buckets } = await this.spheronApi.getOrganizationBuckets({
+      organizationId,
+      ...options,
+    });
+    return buckets.map((x) => this.mapCoreBucket(x));
+  }
+
+  async getOrganizationBucketCount(
+    organizationId: string,
+    options?: {
+      name?: string;
+      state?: BucketStateEnum;
+    }
+  ): Promise<number> {
+    const { count } = await this.spheronApi.getOrganizationBucketCount({
+      organizationId,
+      ...options,
+    });
+    return count;
+  }
+
   async getBucket(bucketId: string): Promise<Bucket> {
     const bucket = await this.spheronApi.getBucket(bucketId);
     return this.mapCoreBucket(bucket);

--- a/packages/storage/src/bucket-manager/interfaces.ts
+++ b/packages/storage/src/bucket-manager/interfaces.ts
@@ -18,10 +18,10 @@ interface IpnsRecord {
   id: string;
   ipnsHash: string;
   ipnsLink: string;
-  publishedUploadId: string;
   bucketId: string;
   createdAt: Date;
   updatedAt: Date;
+  memoryUsed: number;
 }
 
 interface Bucket {

--- a/packages/storage/src/bucket-manager/interfaces.ts
+++ b/packages/storage/src/bucket-manager/interfaces.ts
@@ -1,4 +1,4 @@
-import { DomainTypeEnum, ProjectStateEnum } from "@spheron/core";
+import { BucketStateEnum, DomainTypeEnum } from "@spheron/core";
 
 interface Domain {
   id: string;
@@ -9,14 +9,11 @@ interface Domain {
   type: DomainTypeEnum;
 }
 
-type BucketStateEnum = ProjectStateEnum;
-
 interface Bucket {
   id: string;
   name: string;
   organizationId: string;
   state: BucketStateEnum;
-  domains: Domain[];
 }
 
 enum UploadStatusEnum {

--- a/packages/storage/src/bucket-manager/interfaces.ts
+++ b/packages/storage/src/bucket-manager/interfaces.ts
@@ -14,6 +14,16 @@ interface Domain {
   type: DomainTypeEnum;
 }
 
+interface IpnsRecord {
+  id: string;
+  ipnsHash: string;
+  ipnsLink: string;
+  publishedUploadId: string;
+  bucketId: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 interface Bucket {
   id: string;
   name: string;
@@ -69,4 +79,5 @@ export {
   BucketStateEnum,
   UploadStatusEnum,
   UsageWithLimits,
+  IpnsRecord,
 };

--- a/packages/storage/src/bucket-manager/interfaces.ts
+++ b/packages/storage/src/bucket-manager/interfaces.ts
@@ -2,6 +2,7 @@ import {
   BucketStateEnum,
   DomainTypeEnum,
   UploadStatusEnum,
+  UploadedFile,
 } from "@spheron/core";
 
 interface Domain {
@@ -23,28 +24,41 @@ interface Bucket {
 interface Upload {
   id: string;
   protocolLink: string;
-  uploadDirectory: string[];
+  uploadDirectory: UploadedFile[];
   status: UploadStatusEnum;
   memoryUsed: number;
   bucketId: string;
   protocol: string;
 }
 
+/*
+        "usedImageOptimizations": 0,
+        "imageOptimizationsLimit": 1000
+    */
+
 interface UsageWithLimits {
   used: {
     bandwidth: number; // Bytes
     storageArweave: number; // Bytes
     storageIPFS: number; // Bytes
+    storageFilecoin: number; // Bytes
     domains: number;
+    hnsDomains: number;
+    ensDomains: number;
     numberOfRequests: number;
     parallelUploads: number;
+    imageOptimization: number;
   };
   limit: {
     bandwidth: number; // Bytes
     storageArweave: number; // Bytes
     storageIPFS: number; // Bytes
+    storageFilecoin: number; // Bytes
     domains: number;
+    hnsDomains: number;
+    ensDomains: number;
     parallelUploads: number;
+    imageOptimization: number;
   };
 }
 

--- a/packages/storage/src/bucket-manager/interfaces.ts
+++ b/packages/storage/src/bucket-manager/interfaces.ts
@@ -1,4 +1,8 @@
-import { BucketStateEnum, DomainTypeEnum } from "@spheron/core";
+import {
+  BucketStateEnum,
+  DomainTypeEnum,
+  UploadStatusEnum,
+} from "@spheron/core";
 
 interface Domain {
   id: string;
@@ -16,18 +20,10 @@ interface Bucket {
   state: BucketStateEnum;
 }
 
-enum UploadStatusEnum {
-  PENDING = "Pending",
-  CANCELED = "Canceled",
-  DEPLOYED = "Deployed",
-  FAILED = "Failed",
-  TIMED_OUT = "TimedOut",
-}
-
 interface Upload {
   id: string;
   protocolLink: string;
-  buildDirectory: string[];
+  uploadDirectory: string[];
   status: UploadStatusEnum;
   memoryUsed: number;
   bucketId: string;

--- a/packages/storage/src/bucket-manager/interfaces.ts
+++ b/packages/storage/src/bucket-manager/interfaces.ts
@@ -58,17 +58,19 @@ interface UsageWithLimits {
     numberOfRequests: number;
     parallelUploads: number;
     imageOptimization: number;
+    ipfsBandwidth: number; // Bytes
+    ipfsNumberOfRequests: number;
   };
   limit: {
     bandwidth: number; // Bytes
     storageArweave: number; // Bytes
     storageIPFS: number; // Bytes
-    storageFilecoin: number; // Bytes
     domains: number;
     hnsDomains: number;
     ensDomains: number;
     parallelUploads: number;
     imageOptimization: number;
+    ipfsBandwidth: number; // Bytes
   };
 }
 

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -307,19 +307,11 @@ export class SpheronClient {
     protocolLink: string;
     dynamicLinks: string[];
   }> {
-    const { deploymentId, projectId, sitePreview, affectedDomains } =
-      await this.uploadManager.pinCID({
-        name: configuration.name,
-        token: this.configuration.token,
-        cid: configuration.cid,
-      });
-
-    return {
-      uploadId: deploymentId,
-      bucketId: projectId,
-      protocolLink: sitePreview,
-      dynamicLinks: affectedDomains,
-    };
+    return await this.uploadManager.pinCID({
+      name: configuration.name,
+      token: this.configuration.token,
+      cid: configuration.cid,
+    });
   }
 
   async getBucket(bucketId: string): Promise<Bucket> {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -44,6 +44,8 @@ export {
 
 export interface SpheronClientConfiguration {
   token: string;
+  apiUrl?: string;
+  uploadApiUrl?: string;
 }
 
 export class SpheronClient {
@@ -54,9 +56,12 @@ export class SpheronClient {
 
   constructor(configuration: SpheronClientConfiguration) {
     this.configuration = configuration;
-    this.spheronApi = new SpheronApi(this.configuration.token);
+    this.spheronApi = new SpheronApi(
+      this.configuration.token,
+      configuration?.apiUrl
+    );
     this.bucketManager = new BucketManager(this.spheronApi);
-    this.uploadManager = new UploadManager();
+    this.uploadManager = new UploadManager(configuration?.uploadApiUrl);
   }
 
   async upload(
@@ -310,6 +315,34 @@ export class SpheronClient {
       token: this.configuration.token,
       cid: configuration.cid,
     });
+  }
+
+  async getOrganizationBuckets(
+    organizationId: string,
+    options: {
+      name?: string;
+      state?: BucketStateEnum;
+      skip: number;
+      limit: number;
+    }
+  ): Promise<Bucket[]> {
+    return await this.bucketManager.getOrganizationBuckets(
+      organizationId,
+      options
+    );
+  }
+
+  async getOrganizationBucketCount(
+    organizationId: string,
+    options?: {
+      name?: string;
+      state?: BucketStateEnum;
+    }
+  ): Promise<number> {
+    return await this.bucketManager.getOrganizationBucketCount(
+      organizationId,
+      options
+    );
   }
 
   async getBucket(bucketId: string): Promise<Bucket> {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -439,10 +439,7 @@ export class SpheronClient {
   }
 
   async getBucketUploadCount(bucketId: string): Promise<{
-    total: number;
-    successful: number;
-    failed: number;
-    pending: number;
+    count: number;
   }> {
     return await this.bucketManager.getBucketUploadCount(bucketId);
   }

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -452,7 +452,7 @@ export class SpheronClient {
   async getOrganizationUsage(organizationId: string): Promise<UsageWithLimits> {
     const usage = await this.spheronApi.getOrganizationUsage(
       organizationId,
-      "wa-global"
+      "storage"
     );
 
     return {
@@ -460,16 +460,24 @@ export class SpheronClient {
         bandwidth: usage.usedBandwidth ?? 0,
         storageArweave: usage.usedStorageArweave ?? 0,
         storageIPFS: usage.usedStorageIPFS ?? 0,
+        storageFilecoin: usage.usedStorageFilecoin ?? 0,
         domains: usage.usedDomains ?? 0,
+        hnsDomains: usage.usedHnsDomains ?? 0,
+        ensDomains: usage.usedEnsDomains ?? 0,
         numberOfRequests: usage.usedNumberOfRequests ?? 0,
         parallelUploads: usage.usedParallelUploads ?? 0,
+        imageOptimization: usage.usedImageOptimizations ?? 0,
       },
       limit: {
         bandwidth: usage.bandwidthLimit ?? 0,
         storageArweave: usage.storageArweaveLimit ?? 0,
         storageIPFS: usage.storageIPFSLimit ?? 0,
+        storageFilecoin: usage.storageFilecoinLimit ?? 0,
         domains: usage.domainsLimit ?? 0,
+        hnsDomains: usage.usedHnsDomains ?? 0,
+        ensDomains: usage.usedEnsDomains ?? 0,
         parallelUploads: usage.parallelUploadsLimit ?? 0,
+        imageOptimization: usage.imageOptimizationsLimit ?? 0,
       },
     };
   }

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -45,7 +45,6 @@ export {
 export interface SpheronClientConfiguration {
   token: string;
   apiUrl?: string;
-  uploadApiUrl?: string;
 }
 
 export class SpheronClient {
@@ -61,7 +60,7 @@ export class SpheronClient {
       configuration?.apiUrl
     );
     this.bucketManager = new BucketManager(this.spheronApi);
-    this.uploadManager = new UploadManager(configuration?.uploadApiUrl);
+    this.uploadManager = new UploadManager(configuration?.apiUrl);
   }
 
   async upload(
@@ -528,6 +527,19 @@ export class SpheronClient {
     ipnsRecordId: string
   ): Promise<void> {
     await this.spheronApi.deleteBucketIpnsRecord(bucketId, ipnsRecordId);
+  }
+
+  async migrateWebAppOrgToStorage(
+    webappOrganizationId: string,
+    storageOrganizationId: string
+  ): Promise<{
+    numberOfBuckets: number;
+    numberOfUploads: number;
+  }> {
+    return await this.spheronApi.migrateWebAppOrgToStorage(
+      webappOrganizationId,
+      storageOrganizationId
+    );
   }
 }
 

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -529,14 +529,14 @@ export class SpheronClient {
     await this.spheronApi.deleteBucketIpnsRecord(bucketId, ipnsRecordId);
   }
 
-  async migrateWebAppOrgToStorage(
+  async migrateStaticSiteOrgToStorage(
     webappOrganizationId: string,
     storageOrganizationId: string
   ): Promise<{
     numberOfBuckets: number;
     numberOfUploads: number;
   }> {
-    return await this.spheronApi.migrateWebAppOrgToStorage(
+    return await this.spheronApi.migrateStaticSiteOrgToStorage(
       webappOrganizationId,
       storageOrganizationId
     );

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -441,17 +441,19 @@ export class SpheronClient {
         numberOfRequests: usage.usedNumberOfRequests ?? 0,
         parallelUploads: usage.usedParallelUploads ?? 0,
         imageOptimization: usage.usedImageOptimizations ?? 0,
+        ipfsBandwidth: usage.usedIpfsBandwidth ?? 0,
+        ipfsNumberOfRequests: usage.usedIpfsNumberOfRequests ?? 0,
       },
       limit: {
         bandwidth: usage.bandwidthLimit ?? 0,
         storageArweave: usage.storageArweaveLimit ?? 0,
         storageIPFS: usage.storageIPFSLimit ?? 0,
-        storageFilecoin: usage.storageFilecoinLimit ?? 0,
         domains: usage.domainsLimit ?? 0,
         hnsDomains: usage.usedHnsDomains ?? 0,
         ensDomains: usage.usedEnsDomains ?? 0,
         parallelUploads: usage.parallelUploadsLimit ?? 0,
         imageOptimization: usage.imageOptimizationsLimit ?? 0,
+        ipfsBandwidth: usage.ipfsBandwidthLimit ?? 0,
       },
     };
   }

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -7,7 +7,6 @@ import BucketManager, {
   UploadStatusEnum,
 } from "./bucket-manager";
 import {
-  IPNSName,
   ProtocolEnum,
   SpheronApi,
   TokenScope,
@@ -17,7 +16,7 @@ import {
 } from "@spheron/core";
 import { createPayloads } from "./fs-payload-creator";
 import { ipfs } from "./ipfs.utils";
-import { UsageWithLimits } from "./bucket-manager/interfaces";
+import { IpnsRecord, UsageWithLimits } from "./bucket-manager/interfaces";
 import { DecryptFromIpfsProps, EncryptToIpfsProps } from "./interface";
 import {
   uint8arrayFromString,
@@ -39,8 +38,8 @@ export {
   UploadStatusEnum,
   UsageWithLimits,
   TokenScope,
-  IPNSName,
   uint8arrayToString,
+  IpnsRecord,
 };
 
 export interface SpheronClientConfiguration {
@@ -404,31 +403,6 @@ export class SpheronClient {
     await this.bucketManager.unarchiveBucket(bucketId);
   }
 
-  async publishIPNS(uploadId: string): Promise<IPNSName> {
-    return await this.spheronApi.publishIPNS(uploadId);
-  }
-
-  async updateIPNSName(
-    ipnsNameId: string,
-    uploadId: string
-  ): Promise<IPNSName> {
-    return await this.spheronApi.updateIPNSName(ipnsNameId, uploadId);
-  }
-
-  async getIPNSName(ipnsNameId: string): Promise<IPNSName> {
-    return await this.spheronApi.getIPNSName(ipnsNameId);
-  }
-
-  async getIPNSNamesForUpload(uploadId: string): Promise<IPNSName[]> {
-    return await this.spheronApi.getIPNSNamesForUpload(uploadId);
-  }
-
-  async getIPNSNamesForOrganization(
-    organizationId: string
-  ): Promise<IPNSName[]> {
-    return await this.spheronApi.getIPNSNamesForOrganization(organizationId);
-  }
-
   async getBucketUploadCount(bucketId: string): Promise<{
     count: number;
   }> {
@@ -484,6 +458,43 @@ export class SpheronClient {
 
   async getTokenScope(): Promise<TokenScope> {
     return await this.spheronApi.getTokenScope();
+  }
+
+  async getBucketIpnsRecords(bucketId: string): Promise<IpnsRecord[]> {
+    return await this.bucketManager.getBucketIpnsRecords(bucketId);
+  }
+
+  async getBucketIpnsRecord(
+    bucketId: string,
+    ipnsRecordId: string
+  ): Promise<IpnsRecord> {
+    return await this.bucketManager.getBucketIpnsRecord(bucketId, ipnsRecordId);
+  }
+
+  async addBucketIpnsRecord(
+    bucketId: string,
+    uploadId: string
+  ): Promise<IpnsRecord> {
+    return await this.bucketManager.addBucketIpnsRecord(bucketId, uploadId);
+  }
+
+  async updateBucketIpnsRecord(
+    bucketId: string,
+    ipnsRecordId: string,
+    uploadId: string
+  ): Promise<IpnsRecord> {
+    return await this.bucketManager.updateBucketIpnsRecord(
+      bucketId,
+      ipnsRecordId,
+      uploadId
+    );
+  }
+
+  async deleteBucketIpnsRecord(
+    bucketId: string,
+    ipnsRecordId: string
+  ): Promise<void> {
+    await this.spheronApi.deleteBucketIpnsRecord(bucketId, ipnsRecordId);
   }
 }
 

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -436,9 +436,7 @@ export class SpheronClient {
     await this.bucketManager.unarchiveBucket(bucketId);
   }
 
-  async getBucketUploadCount(bucketId: string): Promise<{
-    count: number;
-  }> {
+  async getBucketUploadCount(bucketId: string): Promise<number> {
     return await this.bucketManager.getBucketUploadCount(bucketId);
   }
 


### PR DESCRIPTION
completes SPH-2901

---

This PR will
1. Increase the version of `browser-upload` to `2.0.0`. From the new version, the uploads will only work for storage organization.
2. Increase the version of `core` to `2.0.0`. Changes made to the core include:
  - Added new methods for interacting with the new bucket, bucket domains, bucket ipns records and upload endpoints
  - Added interfaces for the new entities
  - Updated the UploadManager logic to work with the new upload endpoints.
3. Increase the version of `storage` to `2.0.0`.