### PR TITLE
Add support to define max upload size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6383,9 +6383,9 @@
       }
     },
     "packages/cli/node_modules/@spheron/core": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.10.tgz",
-      "integrity": "sha512-FaB1a+Sjf/1yo+yK/uXpAcg9DIag7ZNfc4CBiyGBVtgRGluiToXOCx+XJKrrdENqHOakAiA3yEeXIYp/bSdAoQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.9.tgz",
+      "integrity": "sha512-FUuD7mlWPUotN+lpT7XfKRBxr5geYLonDi+I66+ECpJuwUS7EYE1k0QsGEXG4tu8OLcW1wxSlarNzcejh0DZIg==",
       "dependencies": {
         "axios": "1.1.2",
         "eventsource": "^2.0.2",
@@ -6413,26 +6413,6 @@
         "multiformats": "^9.9.0"
       }
     },
-    "packages/cli/node_modules/@spheron/storage/node_modules/@spheron/core": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.9.tgz",
-      "integrity": "sha512-FUuD7mlWPUotN+lpT7XfKRBxr5geYLonDi+I66+ECpJuwUS7EYE1k0QsGEXG4tu8OLcW1wxSlarNzcejh0DZIg==",
-      "dependencies": {
-        "axios": "1.1.2",
-        "eventsource": "^2.0.2",
-        "p-limit": "^3.0.0"
-      }
-    },
-    "packages/cli/node_modules/@spheron/storage/node_modules/axios": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
-      "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "packages/compute": {
       "name": "@spheron/compute",
       "version": "1.0.5",
@@ -6452,7 +6432,7 @@
     },
     "packages/core": {
       "name": "@spheron/core",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "async-lock": "^1.4.0",
@@ -6564,12 +6544,33 @@
         "typescript": "^4.9.5"
       }
     },
+    "packages/site/node_modules/@spheron/core": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@spheron/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-WtC5mTDg+WkuhZJBAEqaaTlTM6Jdxe5n9SirM+Xbdc6Pe9WFo0jY55n70revsrApkdJztvnMffxL5gzRRpj16w==",
+      "dependencies": {
+        "async-lock": "^1.4.0",
+        "axios": "1.1.2",
+        "eventsource": "^2.0.2",
+        "p-limit": "^3.0.0"
+      }
+    },
+    "packages/site/node_modules/axios": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
+      "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "packages/storage": {
       "name": "@spheron/storage",
       "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spheron/core": "2.0.1",
+        "@spheron/core": "2.0.2",
         "@spheron/encryption": "1.0.0",
         "form-data": "^4.0.0",
         "multiformats": "^9.9.0"
@@ -7797,9 +7798,9 @@
       },
       "dependencies": {
         "@spheron/core": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.10.tgz",
-          "integrity": "sha512-FaB1a+Sjf/1yo+yK/uXpAcg9DIag7ZNfc4CBiyGBVtgRGluiToXOCx+XJKrrdENqHOakAiA3yEeXIYp/bSdAoQ==",
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.9.tgz",
+          "integrity": "sha512-FUuD7mlWPUotN+lpT7XfKRBxr5geYLonDi+I66+ECpJuwUS7EYE1k0QsGEXG4tu8OLcW1wxSlarNzcejh0DZIg==",
           "requires": {
             "axios": "1.1.2",
             "eventsource": "^2.0.2",
@@ -7827,28 +7828,6 @@
             "@spheron/encryption": "1.0.0",
             "form-data": "^4.0.0",
             "multiformats": "^9.9.0"
-          },
-          "dependencies": {
-            "@spheron/core": {
-              "version": "1.0.9",
-              "resolved": "https://registry.npmjs.org/@spheron/core/-/core-1.0.9.tgz",
-              "integrity": "sha512-FUuD7mlWPUotN+lpT7XfKRBxr5geYLonDi+I66+ECpJuwUS7EYE1k0QsGEXG4tu8OLcW1wxSlarNzcejh0DZIg==",
-              "requires": {
-                "axios": "1.1.2",
-                "eventsource": "^2.0.2",
-                "p-limit": "^3.0.0"
-              }
-            },
-            "axios": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
-              "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
-              "requires": {
-                "follow-redirects": "^1.15.0",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-              }
-            }
           }
         }
       }
@@ -7966,12 +7945,35 @@
         "prettier": "^2.8.3",
         "tsup": "^6.5.0",
         "typescript": "^4.9.5"
+      },
+      "dependencies": {
+        "@spheron/core": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@spheron/core/-/core-2.0.1.tgz",
+          "integrity": "sha512-WtC5mTDg+WkuhZJBAEqaaTlTM6Jdxe5n9SirM+Xbdc6Pe9WFo0jY55n70revsrApkdJztvnMffxL5gzRRpj16w==",
+          "requires": {
+            "async-lock": "^1.4.0",
+            "axios": "1.1.2",
+            "eventsource": "^2.0.2",
+            "p-limit": "^3.0.0"
+          }
+        },
+        "axios": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
+          "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
+          "requires": {
+            "follow-redirects": "^1.15.0",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        }
       }
     },
     "@spheron/storage": {
       "version": "file:packages/storage",
       "requires": {
-        "@spheron/core": "2.0.1",
+        "@spheron/core": "2.0.2",
         "@spheron/encryption": "1.0.0",
         "@types/node": "^18.13.0",
         "@typescript-eslint/eslint-plugin": "^5.51.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/core",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Shared core package for all sdk packages",
   "keywords": [
     "Storage",

--- a/packages/core/src/upload-manager.ts
+++ b/packages/core/src/upload-manager.ts
@@ -37,6 +37,7 @@ class UploadManager {
     organizationId?: string;
     token: string;
     createSingleUseToken?: boolean;
+    maxSize?: number;
   }): Promise<{
     uploadId: string;
     parallelUploadCount: number;
@@ -46,7 +47,9 @@ class UploadManager {
     try {
       this.validateUploadConfiguration(configuration);
 
-      let url = `${this.spheronApiUrl}/v1/upload/initiate?protocol=${configuration.protocol}&bucket=${configuration.name}`;
+      let url = `${this.spheronApiUrl}/v1/upload/initiate?protocol=${
+        configuration.protocol
+      }&bucket=${configuration.name}&maxSize=${configuration.maxSize ?? ""}`;
 
       if (configuration.organizationId) {
         url += `&organization=${configuration.organizationId}`;

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">  
   <a href="https://www.npmjs.com/package/@spheron/storage" target="_blank" rel="noreferrer">
-    <img src="https://img.shields.io/static/v1?label=npm&message=v2.0.1&color=green" />
+    <img src="https://img.shields.io/static/v1?label=npm&message=v2.0.2&color=green" />
   </a>
   <a href="https://github.com/spheronFdn/sdk/blob/main/LICENSE" target="_blank" rel="noreferrer">
     <img src="https://img.shields.io/static/v1?label=license&message=Apache%202.0&color=red" />

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -35,7 +35,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@spheron/core": "2.0.1",
+    "@spheron/core": "2.0.2",
     "@spheron/encryption": "1.0.0",
     "form-data": "^4.0.0",
     "multiformats": "^9.9.0"

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -301,6 +301,7 @@ export class SpheronClient extends ScopeExtractor {
   async createSingleUploadToken(configuration: {
     name: string;
     protocol: ProtocolEnum;
+    maxSize?: number;
   }): Promise<{ uploadToken: string }> {
     await this.validateStorageOrganizationType();
 
@@ -309,6 +310,7 @@ export class SpheronClient extends ScopeExtractor {
       name: configuration.name,
       token: this.configuration.token,
       createSingleUseToken: true,
+      maxSize: configuration.maxSize,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
This PR will:
- Add support to set the max size of an upload in bytes, on `createSingleUploadToken` function. This function is used with the browser-upload, so users will be able to set the max size of uploads to their users.
- Will increase the version of `@spheron/core` to `2.0.2`
- Will increase the version of `@spheron/storage` to `2.0.2`