### PR TITLE
Add the query parameter to execute the pinning in the background

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/core",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Shared core package for all sdk packages",
   "keywords": [
     "Storage",

--- a/packages/core/src/upload-manager.ts
+++ b/packages/core/src/upload-manager.ts
@@ -81,6 +81,7 @@ class UploadManager {
     organizationId?: string;
     token: string;
     cid: string;
+    inBackground?: boolean;
   }): Promise<{
     uploadId: string;
     bucketId: string;
@@ -91,7 +92,11 @@ class UploadManager {
       if (!configuration.name) {
         throw new Error("Bucket name is not provided.");
       }
-      let url = `${this.spheronApiUrl}/v2/ipfs/pin/${configuration.cid}?bucket=${configuration.name}`;
+      let url = `${this.spheronApiUrl}/v2/ipfs/pin/${
+        configuration.cid
+      }?bucket=${configuration.name}&in_background=${
+        configuration.inBackground ? "true" : "false"
+      }`;
 
       if (configuration.organizationId) {
         url += `&organization=${configuration.organizationId}`;

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">  
   <a href="https://www.npmjs.com/package/@spheron/storage" target="_blank" rel="noreferrer">
-    <img src="https://img.shields.io/static/v1?label=npm&message=v2.0.1&color=green" />
+    <img src="https://img.shields.io/static/v1?label=npm&message=v2.0.2&color=green" />
   </a>
   <a href="https://github.com/spheronFdn/sdk/blob/main/LICENSE" target="_blank" rel="noreferrer">
     <img src="https://img.shields.io/static/v1?label=license&message=Apache%202.0&color=red" />

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/storage",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Typescript library for uploading files or directory to  IPFS, Filecoin or Arweave via Spheron",
   "keywords": [
     "Storage",
@@ -35,7 +35,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@spheron/core": "2.0.1",
+    "@spheron/core": "2.0.3",
     "@spheron/encryption": "1.0.0",
     "form-data": "^4.0.0",
     "multiformats": "^9.9.0"

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -315,7 +315,11 @@ export class SpheronClient extends ScopeExtractor {
     return { uploadToken: singleUseToken! };
   }
 
-  async pinCID(configuration: { name: string; cid: string }): Promise<{
+  async pinCID(configuration: {
+    name: string;
+    cid: string;
+    inBackground?: boolean;
+  }): Promise<{
     uploadId: string;
     bucketId: string;
     protocolLink: string;
@@ -327,6 +331,7 @@ export class SpheronClient extends ScopeExtractor {
       name: configuration.name,
       token: this.configuration.token,
       cid: configuration.cid,
+      inBackground: configuration.inBackground,
     });
   }
 


### PR DESCRIPTION
This PR will:
- Add a new query parameter `in_background`, to the pinning endpoint. When this parameter is set to `true` the pinning will be done in the background.
> Note | The response will not have dynamic links duo to this