### PR TITLE
storage: add method for pinning multiple cids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6432,7 +6432,7 @@
     },
     "packages/core": {
       "name": "@spheron/core",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "async-lock": "^1.4.0",
@@ -6567,10 +6567,10 @@
     },
     "packages/storage": {
       "name": "@spheron/storage",
-      "version": "2.0.2",
+      "version": "2.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spheron/core": "2.0.4",
+        "@spheron/core": "2.0.5",
         "@spheron/encryption": "1.0.0",
         "form-data": "^4.0.0",
         "multiformats": "^9.9.0"
@@ -7973,7 +7973,7 @@
     "@spheron/storage": {
       "version": "file:packages/storage",
       "requires": {
-        "@spheron/core": "2.0.4",
+        "@spheron/core": "2.0.5",
         "@spheron/encryption": "1.0.0",
         "@types/node": "^18.13.0",
         "@typescript-eslint/eslint-plugin": "^5.51.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/core",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Shared core package for all sdk packages",
   "keywords": [
     "Storage",

--- a/packages/core/src/upload-manager.ts
+++ b/packages/core/src/upload-manager.ts
@@ -79,6 +79,7 @@ class UploadManager {
       throw new Error(errorMessage);
     }
   }
+
   public async pinCID(configuration: {
     name: string;
     organizationId?: string;
@@ -113,6 +114,50 @@ class UploadManager {
       }>(
         url,
         {},
+        {
+          headers: {
+            Authorization: `Bearer ${configuration.token}`,
+          },
+        }
+      );
+      return response.data;
+    } catch (error) {
+      const errorMessage = error?.response?.data?.message || error?.message;
+      throw new Error(errorMessage);
+    }
+  }
+
+  public async pinCIDs(configuration: {
+    name: string;
+    organizationId?: string;
+    token: string;
+    cids: string[];
+  }): Promise<
+    {
+      uploadId: string;
+      cid: string;
+    }[]
+  > {
+    try {
+      if (!configuration.name) {
+        throw new Error("Bucket name is not provided.");
+      }
+
+      let url = `${this.spheronApiUrl}/v2/ipfs/pins?bucket=${configuration.name}`;
+      if (configuration.organizationId) {
+        url += `&organization=${configuration.organizationId}`;
+      }
+
+      const response = await axios.post<
+        {
+          uploadId: string;
+          cid: string;
+        }[]
+      >(
+        url,
+        {
+          cids: configuration.cids,
+        },
         {
           headers: {
             Authorization: `Bearer ${configuration.token}`,

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">  
   <a href="https://www.npmjs.com/package/@spheron/storage" target="_blank" rel="noreferrer">
-    <img src="https://img.shields.io/static/v1?label=npm&message=v2.0.3&color=green" />
+    <img src="https://img.shields.io/static/v1?label=npm&message=v2.0.4&color=green" />
   </a>
   <a href="https://github.com/spheronFdn/sdk/blob/main/LICENSE" target="_blank" rel="noreferrer">
     <img src="https://img.shields.io/static/v1?label=license&message=Apache%202.0&color=red" />

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/storage",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Typescript library for uploading files or directory to  IPFS, Filecoin or Arweave via Spheron",
   "keywords": [
     "Storage",
@@ -35,7 +35,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@spheron/core": "2.0.4",
+    "@spheron/core": "2.0.5",
     "@spheron/encryption": "1.0.0",
     "form-data": "^4.0.0",
     "multiformats": "^9.9.0"

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -337,6 +337,21 @@ export class SpheronClient extends ScopeExtractor {
     });
   }
 
+  async pinCIDs(configuration: { name: string; cids: string[] }): Promise<
+    {
+      uploadId: string;
+      cid: string;
+    }[]
+  > {
+    await this.validateStorageOrganizationType();
+
+    return await this.uploadManager.pinCIDs({
+      name: configuration.name,
+      cids: configuration.cids,
+      token: this.configuration.token,
+    });
+  }
+
   async getOrganizationBuckets(
     organizationId: string,
     options: {


### PR DESCRIPTION
This PR will:
- Add a new method called `pinCIDs`. This method can be used to send multiple CID to the pinning queue, and the return value of it will contain an array of upload id's that can be used later to check that status of the pin.
```js
async pinCIDs(configuration: { name: string; cids: string[] }): Promise<
    {
      uploadId: string;
      cid: string;
    }[]
  >
```
- increase the version of the `@spheron/core` package to `2.0.5`
- increase the version of the `@spheron/storage` package to `2.0.4`