### PR TITLE
browser-upload: fix the total size for files larger than 5mb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6302,7 +6302,7 @@
     },
     "packages/browser-upload": {
       "name": "@spheron/browser-upload",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@spheron/core": "2.0.0",
@@ -6567,7 +6567,7 @@
     },
     "packages/storage": {
       "name": "@spheron/storage",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@spheron/core": "2.0.4",

--- a/packages/browser-upload/README.md
+++ b/packages/browser-upload/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">  
   <a href="https://www.npmjs.com/package/@spheron/storage" target="_blank" rel="noreferrer">
-    <img src="https://img.shields.io/static/v1?label=npm&message=v2.0.0&color=green" />
+    <img src="https://img.shields.io/static/v1?label=npm&message=v2.0.1&color=green" />
   </a>
   <a href="https://github.com/spheronFdn/sdk/blob/main/LICENSE" target="_blank" rel="noreferrer">
     <img src="https://img.shields.io/static/v1?label=license&message=Apache%202.0&color=red" />

--- a/packages/browser-upload/package.json
+++ b/packages/browser-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spheron/browser-upload",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Typescript library for uploading files or directory from the Browser to  IPFS, Filecoin or Arweave via Spheron",
   "keywords": [
     "Storage",

--- a/packages/browser-upload/src/file-payload-creator.ts
+++ b/packages/browser-upload/src/file-payload-creator.ts
@@ -22,6 +22,7 @@ const createPayloads = async (
   };
 
   files.forEach((file) => {
+    uploadContext.totalSize += file.size;
     if (file.size > payloadSize) {
       const chunks = splitFileIntoChunks(file, payloadSize);
       chunks.forEach((chunk, index) => {
@@ -34,7 +35,6 @@ const createPayloads = async (
         uploadContext.payloads.push(form);
       });
     } else {
-      uploadContext.totalSize += file.size;
       if (!uploadContext.currentPayload) {
         uploadContext.currentPayload = new FormData();
       }


### PR DESCRIPTION
This PR will:
- increase the version of `browser-upload` to `2.0.1`
- Fix the bug that the `totalSize` was not being increased for files larger than the `payloadSize`